### PR TITLE
[ISSUE-267]Fix the blog page activated style

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -130,7 +130,7 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
           to: 'blog',
           label: 'Blog',
           position: 'left',
-          activeBaseRegex: `/blog/`,
+          activeBaseRegex: `/blog`,
         },
         {
           to: '/team',


### PR DESCRIPTION
删除blog后面的斜线，此处因为斜线导致正则匹配时候失效
#267 