### PR TITLE
Add a doc specification

### DIFF
--- a/community/how-to-contribute-to-website.md
+++ b/community/how-to-contribute-to-website.md
@@ -151,6 +151,10 @@ Located in `src/pages/versions`
         index.jsorchestrator/overview.md
         index.less
 ```
+
+### 3.9 Path specification
+In the markdown document, if you want to jump to another document such as `/community/how-to-email.md`, you need to remove the suffix `.md`(written as `/community/how-to-email`) from the path.
+
 ## 4 New documents
 
 ![#f03c15](https://via.placeholder.com/15/f03c15/000000?text=+) The md document is recommended to be viewed by visiting the official website and viewing the md document through github. There is a problem that static resources such as pictures cannot be displayed correctly

--- a/i18n/zh-CN/docusaurus-plugin-content-docs-community/current/how-to-contribute-to-website.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs-community/current/how-to-contribute-to-website.md
@@ -151,6 +151,10 @@ css等样式文件放在`src/css`目录下
         index.jsorchestrator/overview.md
         index.less
 ```
+
+### 3.9  路径规范
+在markdown文档中若要跳转到另一个文档如`/community/how-to-email.md`，则该路径需要删除`.md`后缀（写成`/community/how-to-email`）。
+
 ## 4 新增文档
 
 ![#f03c15](https://via.placeholder.com/15/f03c15/000000?text=+) md文档建议通过访问官网查看,通过github查看md文档存在图片等静态资源无法正确显示问题


### PR DESCRIPTION
In order to be properly detected by [untitaker/hyperlink@0.1.21], I have added some normative guidelines for the use of soft links in markdown files.
![微信截图_20220627083313](https://user-images.githubusercontent.com/89081023/175840617-0a638cf8-a967-4d5f-915a-d9a4decca932.png)

