### PR TITLE
Fix a problem of automatically closing the issue robot

### DIFF
--- a/.github/actions/Auto_close_associate_issue/main.js
+++ b/.github/actions/Auto_close_associate_issue/main.js
@@ -2,6 +2,14 @@ let body = process.env['INPUT_PRBODY'];
 
 let pattern = /#\d+/;
 
-let issueNumber = body.match(pattern)[0].replace('#', '');
+let issueNumber;
+
+try {
+    issueNumber = body.match(pattern)[0].replace('#', '');
+} catch{
+    issueNumber = -1;
+}
+
 
 console.log(`::set-output name=issueNumber::${issueNumber}`);
+

--- a/.github/workflows/auto-close-issue.yml
+++ b/.github/workflows/auto-close-issue.yml
@@ -20,7 +20,7 @@ jobs:
         uses: peter-evans/close-issue@v2
         if: ${{ github.event.pull_request.merged }}
         with:
-          issue-number: ${{ steps.Closer.outputs.issueNumber }}
+          issue-number: ${{ steps.Closer.outputs.issueNumber && steps.Closer.outputs.issueNumber != -1 }}
           comment: The associated PR has been merged, this issue is automatically closed, you can reopend if necessary.
         env:
           Github_Token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
When a PR without associated issue is merged, the robot that automatically closes the issue does not work well: [action job link](https://github.com/apache/incubator-linkis-website/actions/runs/2623305449). This PR will solve this problem