### PR TITLE
Update blog: "How to Download Engine Plugins Not Included in the Installation Package By Default"

### DIFF
--- a/blog/2022-04-15-how-to-download-engineconn-plugin.md
+++ b/blog/2022-04-15-how-to-download-engineconn-plugin.md
@@ -9,6 +9,36 @@ Considering the size of the release package and the use of plug-ins, the binary 
 Very useful engine, there are flink/io_file/pipeline/sqoop in the project code (there may be differences between different versions),
 In order to facilitate everyone's use, based on the release branch code of each version of linkis: https://github.com/apache/incubator-linkis, this part of the engine is compiled for everyone to choose and use.
 
+## 1.1.2 版本
+
+| **Engine** | **Corresponding component version** | Is there default in the official installation package | **Description** |
+|:---- |:---- |:---- |:---- |:---- |
+|Spark|2.4.3|Yes|Spark EngineConn. Support SQL, Scala, Pyspark and R code|
+|Hive|2.3.3|Yes|Hive EngineConn. Support HiveQL code.|
+|Shell||Yes|Shell EngineConn. Support Bash shell code.|
+|Python||Yes|Python EngineConn. Support Python code.|
+|JDBC| |No|JDBC EngineConn. MySQL and hiveql have been supported, and other engines with jdbc driver package can be quickly extended, such as Oracle.|
+|Flink |1.12.2|No| Flink EngineConn. It supports FlinkSQL code and launching a new Yarn application in the form of Flink jar.|
+|openLooKeng |1.5.0|No| openLooKeng EngineConn. Support SQL query data virtualization engine openlookeng.|
+|sqoop |1.4.6|No|Sqoop EngineConn. Support data migration tool sqoop engine.|
+
+
+[Non-default engine download link](https://osp-1257653870.cos.ap-guangzhou.myqcloud.com/WeDatasphere/Linkis/engineconn-plugin/1.1.2-engineconn-plugin.tar)
+
+
+## 1.1.1版本
+
+| **Engine** | **Corresponding component version** | Is there default in the official installation package | **Description** |
+|:---- |:---- |:---- |:---- |:---- |
+|Spark|2.4.3|Yes|Spark EngineConn. Support SQL, Scala, Pyspark and R code|
+|Hive|2.3.3|Yes|Hive EngineConn. Support HiveQL code.|
+|Shell||Yes|Shell EngineConn. Support Bash shell code.|
+|Python||Yes|Python EngineConn. Support Python code.|
+|JDBC| |No|JDBC EngineConn. MySQL and hiveql have been supported, and other engines with jdbc driver package can be quickly extended, such as Oracle.|
+|Flink |1.12.2|No| Flink EngineConn. It supports FlinkSQL code and launching a new Yarn application in the form of Flink jar.|
+|openLooKeng |1.5.0|No| openLooKeng EngineConn. Support SQL query data virtualization engine openlookeng.|
+
+[Non-default engine download link](https://osp-1257653870.cos.ap-guangzhou.myqcloud.com/WeDatasphere/Linkis/engineconn-plugin/1.1.1-engineconn-plugin.tar)
 
 ## Version 1.1.0
 
@@ -21,8 +51,7 @@ In order to facilitate everyone's use, based on the release branch code of each 
 |JDBC| |No|JDBC EngineConn. Already supports MySQL and HiveQL, and can be quickly extended to support other engines with JDBC Driver packages, such as Oracle.|
 |Flink |1.12.2|No | Flink EngineConn. Supports FlinkSQL code, and also supports launching a new Yarn application in the form of Flink Jar. |
 
-Non-default engine download link
-https://osp-1257653870.cos.ap-guangzhou.myqcloud.com/WeDatasphere/Linkis/engineconn-plugin/1.0.1-engineconn-plugin.tar
+[Non-default engine download link](https://osp-1257653870.cos.ap-guangzhou.myqcloud.com/WeDatasphere/Linkis/engineconn-plugin/1.0.1-engineconn-plugin.tar)
 
 
 
@@ -37,8 +66,7 @@ https://osp-1257653870.cos.ap-guangzhou.myqcloud.com/WeDatasphere/Linkis/enginec
 |JDBC| |No|JDBC EngineConn. Already supports MySQL and HiveQL, and can be quickly extended to support other engines with JDBC Driver packages, such as Oracle.|
 |Flink |1.12.2|No | Flink EngineConn. Supports FlinkSQL code, and also supports launching a new Yarn application in the form of Flink Jar. |
 
-Non-default engine download link
-https://osp-1257653870.cos.ap-guangzhou.myqcloud.com/WeDatasphere/Linkis/engineconn-plugin/1.0.3-engineconn-plugin.tar
+[Non-default engine download link](https://osp-1257653870.cos.ap-guangzhou.myqcloud.com/WeDatasphere/Linkis/engineconn-plugin/1.0.3-engineconn-plugin.tar)
 
 
 
@@ -54,4 +82,4 @@ cd 1.0.3-engineconn-plugin
 Copy the engine material package to be used to the engine plug-in directory of linkis, and then refresh the engine material.
 
 
-Detailed process reference[Installing EngineConnPlugin engine](https://linkis.apache.org/zh-CN/docs/latest/deployment/engine_conn_plugin_installation)
+Detailed process reference[Installing EngineConnPlugin engine](https://linkis.apache.org/zh-CN/docs/latest/deployment/engine_conn_plugin_installation).

--- a/i18n/zh-CN/docusaurus-plugin-content-blog/2022-04-15-how-to-download-engineconn-plugin.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-blog/2022-04-15-how-to-download-engineconn-plugin.md
@@ -9,34 +9,63 @@ tags: [engine,guide]
 非常用引擎，项目代码中有flink/io_file/pipeline/sqoop(不同版本之间可能有区别)，
 为了方便大家使用，基于linkis每个版本的release分支代码: https://github.com/apache/incubator-linkis, 编译出这部分引擎，供大家选择使用。
 
+## 1.1.2 版本
+
+| **引擎** | **对应的组件版本** | 官方安装包中是否默认有| **说明** |
+|:---- |:---- |:---- |:---- |:---- |
+|Spark|2.4.3|是|Spark EngineConn。 支持SQL, Scala, Pyspark 和R 代码。|
+|Hive|2.3.3|是|Hive EngineConn。 支持HiveQL 代码。|
+|Shell||是|Shell EngineConn。 支持Bash shell 代码。|
+|Python||是|Python EngineConn。 支持python 代码。|
+|JDBC| |否|JDBC EngineConn。 已支持MySQL 和HiveQL，可快速扩展支持其他有JDBC Driver 包的引擎, 如Oracle。|
+|Flink |1.12.2|否| Flink EngineConn。支持FlinkSQL 代码，也支持以Flink Jar 形式启动一个新的Yarn 应用程序。|
+|openLooKeng |1.5.0|否| openLooKeng EngineConn。 支持用Sql查询数据虚拟化引擎openLooKeng。|
+|sqoop |1.4.6|否|Sqoop EngineConn。 支持 数据迁移工具 Sqoop 引擎。|
+
+
+[非默认引擎下载链接](https://osp-1257653870.cos.ap-guangzhou.myqcloud.com/WeDatasphere/Linkis/engineconn-plugin/1.1.2-engineconn-plugin.tar)
+
+
+## 1.1.1版本
+
+| **引擎** | **对应的组件版本** | 官方安装包中是否默认有| **说明** |
+|:---- |:---- |:---- |:---- |:---- |
+|Spark|2.4.3|是|Spark EngineConn。 支持SQL, Scala, Pyspark 和R 代码。|
+|Hive|2.3.3|是|Hive EngineConn。 支持HiveQL 代码。|
+|Shell||是|Shell EngineConn。 支持Bash shell 代码。|
+|Python||是|Python EngineConn。 支持python 代码。|
+|JDBC| |否|JDBC EngineConn。 已支持MySQL 和HiveQL，可快速扩展支持其他有JDBC Driver 包的引擎, 如Oracle。|
+|Flink |1.12.2|否| Flink EngineConn。支持FlinkSQL 代码，也支持以Flink Jar 形式启动一个新的Yarn 应用程序。|
+|openLooKeng |1.5.0|否| openLooKeng EngineConn。 支持用Sql查询数据虚拟化引擎openLooKeng。|
+
+[非默认引擎下载链接](https://osp-1257653870.cos.ap-guangzhou.myqcloud.com/WeDatasphere/Linkis/engineconn-plugin/1.1.1-engineconn-plugin.tar)
+
 ## 1.1.0 版本
 
 | **引擎** | **对应的组件版本** | 官方安装包中是否默认有| **说明** |
 |:---- |:---- |:---- |:---- |:---- |
-|Spark|2.4.3|是|Spark EngineConn. 支持SQL, Scala, Pyspark 和R 代码.|
-|Hive|2.3.3|是1|Hive EngineConn. 支持HiveQL 代码.|
-|Shell||是|Shell EngineConn. 支持Bash shell 代码.|
-|Python||是|Python EngineConn. 支持python 代码.|
-|JDBC| |否|JDBC EngineConn. 已支持MySQL 和HiveQL，可快速扩展支持其他有JDBC Driver 包的引擎, 如Oracle.|
+|Spark|2.4.3|是|Spark EngineConn。 支持SQL, Scala, Pyspark 和R 代码。|
+|Hive|2.3.3|是|Hive EngineConn。 支持HiveQL 代码。|
+|Shell||是|Shell EngineConn。 支持Bash shell 代码。|
+|Python||是|Python EngineConn。 支持python 代码。|
+|JDBC| |否|JDBC EngineConn。 已支持MySQL 和HiveQL，可快速扩展支持其他有JDBC Driver 包的引擎, 如Oracle。|
 |Flink |1.12.2|否|	Flink EngineConn。支持FlinkSQL 代码，也支持以Flink Jar 形式启动一个新的Yarn 应用程序。|
 
-非默认引擎下载链接
-https://osp-1257653870.cos.ap-guangzhou.myqcloud.com/WeDatasphere/Linkis/engineconn-plugin/1.0.1-engineconn-plugin.tar
+[非默认引擎下载链接](https://osp-1257653870.cos.ap-guangzhou.myqcloud.com/WeDatasphere/Linkis/engineconn-plugin/1.0.1-engineconn-plugin.tar)
 
 
 ## 1.0.3版本
 
 | **引擎** | **对应的组件版本** | 官方安装包中是否默认有| **说明** |
 |:---- |:---- |:---- |:---- |:---- |
-|Spark|2.4.3|是|Spark EngineConn. 支持SQL, Scala, Pyspark 和R 代码.|
-|Hive|2.3.3|是1|Hive EngineConn. 支持HiveQL 代码.|
-|Shell||是|Shell EngineConn. 支持Bash shell 代码.|
-|Python||是|Python EngineConn. 支持python 代码.|
-|JDBC| |否|JDBC EngineConn. 已支持MySQL 和HiveQL，可快速扩展支持其他有JDBC Driver 包的引擎, 如Oracle.|
+|Spark|2.4.3|是|Spark EngineConn。 支持SQL, Scala, Pyspark 和R 代码。|
+|Hive|2.3.3|是|Hive EngineConn。 支持HiveQL 代码。|
+|Shell||是|Shell EngineConn。 支持Bash shell 代码。|
+|Python||是|Python EngineConn。 支持python 代码。|
+|JDBC| |否|JDBC EngineConn。 已支持MySQL 和HiveQL，可快速扩展支持其他有JDBC Driver 包的引擎, 如Oracle。|
 |Flink |1.12.2|否|	Flink EngineConn。支持FlinkSQL 代码，也支持以Flink Jar 形式启动一个新的Yarn 应用程序。|
 
-非默认引擎下载链接
-https://osp-1257653870.cos.ap-guangzhou.myqcloud.com/WeDatasphere/Linkis/engineconn-plugin/1.0.3-engineconn-plugin.tar 
+[非默认引擎下载链接](https://osp-1257653870.cos.ap-guangzhou.myqcloud.com/WeDatasphere/Linkis/engineconn-plugin/1.0.3-engineconn-plugin.tar)
 
 
 ## 安装引擎指引 
@@ -50,5 +79,5 @@ cd 1.0.3-engineconn-plugin
 
 将需要要使用的引擎物料包拷贝至linkis的引擎插件目录，然后刷新引擎物料即可
 
-详细流程参考[安装 EngineConnPlugin 引擎](https://linkis.apache.org/zh-CN/docs/latest/deployment/engine_conn_plugin_installation)
+详细流程参考[安装 EngineConnPlugin 引擎](https://linkis.apache.org/zh-CN/docs/latest/deployment/engine_conn_plugin_installation)。
 


### PR DESCRIPTION
Add engine download guide for version 1.1.1 and version 1.1.2.