### PR TITLE
Add cache expiration time configuration description

### DIFF
--- a/docs/tuning-and-troubleshooting/configuration.md
+++ b/docs/tuning-and-troubleshooting/configuration.md
@@ -59,6 +59,7 @@ sidebar_position: 1
 | wds.linkis.rpc.sender.asyn.consumer.thread.max", 5 | Sender Consumer maximum number of threads |
 | wds.linkis.rpc.sender.asyn.consumer.freeTime.max | 2m | Sender Consumer Maximum Free Time |
 | wds.linkis.rpc.sender.asyn.queue.size.max | 300 | Sender consumption queue maximum buffer number |
+| wds.linkis.rpc.cache.expire.time | 120000 liters | Linkis RPC storage expiration time |
 
 ### 2. Calculate governance configuration parameters
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/tuning-and-troubleshooting/configuration.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/tuning-and-troubleshooting/configuration.md
@@ -57,6 +57,7 @@ sidebar_position: 1
 | wds.linkis.rpc.sender.asyn.consumer.thread.max", 5 | Sender Consumer最大线程数量 |
 | wds.linkis.rpc.sender.asyn.consumer.freeTime.max | 2m | Sender Consumer最大空闲时间 |
 | wds.linkis.rpc.sender.asyn.queue.size.max | 300 | Sender 消费队列最大缓存数 |
+| wds.linkis.rpc.cache.expire.time | 120000L | Linkis RPC 缓存失效时间 |
 
 ### 2. 计算治理配置参数
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.1.1/tuning-and-troubleshooting/configuration.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.1.1/tuning-and-troubleshooting/configuration.md
@@ -57,6 +57,7 @@ sidebar_position: 1
 | wds.linkis.rpc.sender.asyn.consumer.thread.max", 5 | Sender Consumer最大线程数量 |
 | wds.linkis.rpc.sender.asyn.consumer.freeTime.max | 2m | Sender Consumer最大空闲时间 |
 | wds.linkis.rpc.sender.asyn.queue.size.max | 300 | Sender 消费队列最大缓存数 |
+| wds.linkis.rpc.cache.expire.time | 120000L | Linkis RPC 缓存失效时间 |
 
 ### 2. 计算治理配置参数
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.1.2/tuning-and-troubleshooting/configuration.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.1.2/tuning-and-troubleshooting/configuration.md
@@ -57,6 +57,7 @@ sidebar_position: 1
 | wds.linkis.rpc.sender.asyn.consumer.thread.max", 5 | Sender Consumer最大线程数量 |
 | wds.linkis.rpc.sender.asyn.consumer.freeTime.max | 2m | Sender Consumer最大空闲时间 |
 | wds.linkis.rpc.sender.asyn.queue.size.max | 300 | Sender 消费队列最大缓存数 |
+| wds.linkis.rpc.cache.expire.time | 120000L | Linkis RPC 缓存失效时间 |
 
 ### 2. 计算治理配置参数
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.1.3/tuning-and-troubleshooting/configuration.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.1.3/tuning-and-troubleshooting/configuration.md
@@ -57,6 +57,7 @@ sidebar_position: 1
 | wds.linkis.rpc.sender.asyn.consumer.thread.max", 5 | Sender Consumer最大线程数量 |
 | wds.linkis.rpc.sender.asyn.consumer.freeTime.max | 2m | Sender Consumer最大空闲时间 |
 | wds.linkis.rpc.sender.asyn.queue.size.max | 300 | Sender 消费队列最大缓存数 |
+| wds.linkis.rpc.cache.expire.time | 120000L | Linkis RPC 缓存失效时间 |
 
 ### 2. 计算治理配置参数
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.2.0/tuning-and-troubleshooting/configuration.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.2.0/tuning-and-troubleshooting/configuration.md
@@ -57,6 +57,7 @@ sidebar_position: 1
 | wds.linkis.rpc.sender.asyn.consumer.thread.max", 5 | Sender Consumer最大线程数量 |
 | wds.linkis.rpc.sender.asyn.consumer.freeTime.max | 2m | Sender Consumer最大空闲时间 |
 | wds.linkis.rpc.sender.asyn.queue.size.max | 300 | Sender 消费队列最大缓存数 |
+| wds.linkis.rpc.cache.expire.time | 120000L | Linkis RPC 缓存失效时间 |
 
 ### 2. 计算治理配置参数
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.0/tuning-and-troubleshooting/configuration.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.0/tuning-and-troubleshooting/configuration.md
@@ -57,6 +57,7 @@ sidebar_position: 1
 | wds.linkis.rpc.sender.asyn.consumer.thread.max", 5 | Sender Consumer最大线程数量 |
 | wds.linkis.rpc.sender.asyn.consumer.freeTime.max | 2m | Sender Consumer最大空闲时间 |
 | wds.linkis.rpc.sender.asyn.queue.size.max | 300 | Sender 消费队列最大缓存数 |
+| wds.linkis.rpc.cache.expire.time | 120000L | Linkis RPC 缓存失效时间 |
 
 ### 2. 计算治理配置参数
 

--- a/versioned_docs/version-1.1.0/tuning-and-troubleshooting/configuration.md
+++ b/versioned_docs/version-1.1.0/tuning-and-troubleshooting/configuration.md
@@ -59,6 +59,7 @@ sidebar_position: 1
 | wds.linkis.rpc.sender.asyn.consumer.thread.max", 5 | Sender Consumer maximum number of threads |
 | wds.linkis.rpc.sender.asyn.consumer.freeTime.max | 2m | Sender Consumer Maximum Free Time |
 | wds.linkis.rpc.sender.asyn.queue.size.max | 300 | Sender consumption queue maximum buffer number |
+| wds.linkis.rpc.cache.expire.time | 120000 liters | Linkis RPC storage expiration time |
 
 ### 2. Calculate governance configuration parameters
 

--- a/versioned_docs/version-1.1.1/tuning-and-troubleshooting/configuration.md
+++ b/versioned_docs/version-1.1.1/tuning-and-troubleshooting/configuration.md
@@ -59,6 +59,7 @@ sidebar_position: 1
 | wds.linkis.rpc.sender.asyn.consumer.thread.max", 5 | Sender Consumer maximum number of threads |
 | wds.linkis.rpc.sender.asyn.consumer.freeTime.max | 2m | Sender Consumer Maximum Free Time |
 | wds.linkis.rpc.sender.asyn.queue.size.max | 300 | Sender consumption queue maximum buffer number |
+| wds.linkis.rpc.cache.expire.time | 120000 liters | Linkis RPC storage expiration time |
 
 ### 2. Calculate governance configuration parameters
 

--- a/versioned_docs/version-1.1.2/tuning-and-troubleshooting/configuration.md
+++ b/versioned_docs/version-1.1.2/tuning-and-troubleshooting/configuration.md
@@ -59,6 +59,7 @@ sidebar_position: 1
 | wds.linkis.rpc.sender.asyn.consumer.thread.max", 5 | Sender Consumer maximum number of threads |
 | wds.linkis.rpc.sender.asyn.consumer.freeTime.max | 2m | Sender Consumer Maximum Free Time |
 | wds.linkis.rpc.sender.asyn.queue.size.max | 300 | Sender consumption queue maximum buffer number |
+| wds.linkis.rpc.cache.expire.time | 120000 liters | Linkis RPC storage expiration time |
 
 ### 2. Calculate governance configuration parameters
 

--- a/versioned_docs/version-1.1.3/tuning-and-troubleshooting/configuration.md
+++ b/versioned_docs/version-1.1.3/tuning-and-troubleshooting/configuration.md
@@ -59,6 +59,7 @@ sidebar_position: 1
 | wds.linkis.rpc.sender.asyn.consumer.thread.max", 5 | Sender Consumer maximum number of threads |
 | wds.linkis.rpc.sender.asyn.consumer.freeTime.max | 2m | Sender Consumer Maximum Free Time |
 | wds.linkis.rpc.sender.asyn.queue.size.max | 300 | Sender consumption queue maximum buffer number |
+| wds.linkis.rpc.cache.expire.time | 120000 liters | Linkis RPC storage expiration time |
 
 ### 2. Calculate governance configuration parameters
 

--- a/versioned_docs/version-1.2.0/tuning-and-troubleshooting/configuration.md
+++ b/versioned_docs/version-1.2.0/tuning-and-troubleshooting/configuration.md
@@ -59,6 +59,7 @@ sidebar_position: 1
 | wds.linkis.rpc.sender.asyn.consumer.thread.max", 5 | Sender Consumer maximum number of threads |
 | wds.linkis.rpc.sender.asyn.consumer.freeTime.max | 2m | Sender Consumer Maximum Free Time |
 | wds.linkis.rpc.sender.asyn.queue.size.max | 300 | Sender consumption queue maximum buffer number |
+| wds.linkis.rpc.cache.expire.time | 120000 liters | Linkis RPC storage expiration time |
 
 ### 2. Calculate governance configuration parameters
 

--- a/versioned_docs/version-1.3.0/tuning-and-troubleshooting/configuration.md
+++ b/versioned_docs/version-1.3.0/tuning-and-troubleshooting/configuration.md
@@ -59,6 +59,7 @@ sidebar_position: 1
 | wds.linkis.rpc.sender.asyn.consumer.thread.max", 5 | Sender Consumer maximum number of threads |
 | wds.linkis.rpc.sender.asyn.consumer.freeTime.max | 2m | Sender Consumer Maximum Free Time |
 | wds.linkis.rpc.sender.asyn.queue.size.max | 300 | Sender consumption queue maximum buffer number |
+| wds.linkis.rpc.cache.expire.time | 120000 liters | Linkis RPC storage expiration time |
 
 ### 2. Calculate governance configuration parameters
 


### PR DESCRIPTION
If the cache time is too long, it is recommended to reduce the parameter value (For example, the JDBC Engine console configuration cannot take effect immediately due to caching)

**Related PRs**

Related pr:https://github.com/apache/incubator-linkis-website/pull/262