### PR TITLE
Remove test scope of mysql-connector-java for debug

### DIFF
--- a/docs/development/debug.md
+++ b/docs/development/debug.md
@@ -52,6 +52,7 @@ The way to add to the dependency is as follows, modify the pom.xml file of the c
       <version>${mysql.connector.version}</version>
 </dependency>
 ````
+At the same time, it is necessary to keep whether the scope of mysql-connector-java dependency is set to test according to the <dependencyManagement> of pom.xml. If so, comments are required for local debugging
 
 ### 3.2 Adjust log4j2.xml configuration
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/development/debug.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/development/debug.md
@@ -52,6 +52,7 @@ mvn clean install -DskipTests
       <version>${mysql.connector.version}</version>
 </dependency>
 ```
+同时需要留意 根pom.xml的<dependencyManagement>中是否将mysql-connector-java依赖的scope设置为test，如是，本地调试时需要注释掉
 
 ### 3.2 调整log4j2.xml配置
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.0/development/debug.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.0/development/debug.md
@@ -52,6 +52,7 @@ mvn clean install -DskipTests
       <version>${mysql.connector.version}</version>
 </dependency>
 ```
+同时需要留意 根pom.xml的<dependencyManagement>中是否将mysql-connector-java依赖的scope设置为test，如是，本地调试时需要注释掉
 
 ### 3.2 调整log4j2.xml配置
 

--- a/versioned_docs/version-1.2.0/development/linkis-debug.md
+++ b/versioned_docs/version-1.2.0/development/linkis-debug.md
@@ -52,6 +52,7 @@ The way to add to the dependency is as follows, modify the pom.xml file of the c
       <version>${mysql.connector.version}</version>
 </dependency>
 ````
+At the same time, it is necessary to keep whether the scope of mysql-connector-java dependency is set to test according to the <dependencyManagement> of pom.xml. If so, comments are required for local debugging
 
 ### 3.2 Adjust log4j2.xml configuration
 

--- a/versioned_docs/version-1.3.0/development/debug.md
+++ b/versioned_docs/version-1.3.0/development/debug.md
@@ -52,6 +52,7 @@ The way to add to the dependency is as follows, modify the pom.xml file of the c
       <version>${mysql.connector.version}</version>
 </dependency>
 ````
+At the same time, it is necessary to keep whether the scope of mysql-connector-java dependency is set to test according to the <dependencyManagement> of pom.xml. If so, comments are required for local debugging
 
 ### 3.2 Adjust log4j2.xml configuration
 


### PR DESCRIPTION
**In order to support local debugging, you also need to comment out the mysql dependency scope test**

Related PRs

Related pr:https://github.com/apache/incubator-linkis-website/pull/520