### PR TITLE
[feat:4025] docusaurus upgrade from 2.0.0-beta.6 to 2.2.0

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -70,12 +70,6 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
           },
           blogSidebarCount: 'ALL'
         },
-      community: {
-          // routeBasePath: '/',
-          path: 'community',
-          sidebarPath: require.resolve('./sidebars.js'),
-          sidebarCollapsible: true,
-            },
         theme: {
           customCss: require.resolve('./src/css/custom.scss'),
         },

--- a/package.json
+++ b/package.json
@@ -16,11 +16,11 @@
     "crowdin": "crowdin"
   },
   "dependencies": {
-    "@docusaurus/core": "2.0.0-beta.6",
-    "@docusaurus/plugin-client-redirects": "2.0.0-beta.6",
-    "@docusaurus/plugin-content-docs": "2.0.0-beta.6",
-    "@docusaurus/preset-classic": "2.0.0-beta.6",
-    "@docusaurus/theme-search-algolia": "2.0.0-beta.6",
+    "@docusaurus/core": "2.2.0",
+    "@docusaurus/plugin-client-redirects": "2.2.0",
+    "@docusaurus/plugin-content-docs": "2.2.0",
+    "@docusaurus/preset-classic": "2.2.0",
+    "@docusaurus/theme-search-algolia": "2.2.0",
     "docusaurus-plugin-less": "^2.0.2",
     "lodash-es": "^4.17.21",
     "prism-react-renderer": "^1.2.1",


### PR DESCRIPTION
docusaurus upgrade from 2.0.0-beta.6 to 2.2.0 https://github.com/apache/incubator-linkis/issues/4025
The node version >= 16.14 after  upgrade.
You can use nvm to manage the node version.

nvm Common commands
nvm install latest  //Install the latest version node
nvm ls  //list node versions managed by the nvm
nvm use 16.18.1 //switching node versions


