### PR TITLE
Remove version prefix 'v'

### DIFF
--- a/docs/deployment/deploy-quick.md
+++ b/docs/deployment/deploy-quick.md
@@ -447,17 +447,17 @@ linkis-package/lib/linkis-engineconn-plugins/
 │ └── 2.3.3
 ├── python
 │ ├── dist
-│ │ └── vpython2
+│ │ └── python2
 │ └── plugin
 │ └── python2 #version is python2 engineType is python-python2
 ├── shell
 │ ├── dist
-│ │ └── v1
+│ │ └── 1
 │ └── plugin
 │ └── 1
 └── spark
     ├── dist
-    │ └── v2.4.3
+    │ └── 2.4.3
     └── plugin
         └── 2.4.3
 ````

--- a/docs/deployment/install-engineconn.md
+++ b/docs/deployment/install-engineconn.md
@@ -12,7 +12,7 @@ In order to facilitate the EngineConnManager to be loaded into the corresponding
 ```
 hive: engine home directory, must be the name of the engine
 └── dist # Dependency and configuration required for engine startup, different versions of the engine need to be in this directory to prevent the corresponding version directory
-    └── v1.2.1 #Must start with ‘v’ and add engine version number ‘1.2.1’
+    └── 1.2.1 #Must start with ‘v’ and add engine version number ‘1.2.1’
         └── conf # Configuration file directory required by the engine
         └── lib # Dependency package required by EngineConnPlugin
 └── plugin #EngineConnPlugin directory, this directory is used for engine management service package engine startup command and resource application

--- a/docs/engine-usage/elasticsearch.md
+++ b/docs/engine-usage/elasticsearch.md
@@ -65,12 +65,12 @@ The directory structure after uploading is as follows
 ```
 linkis-engineconn-plugins/
 ├── elasticsearch
-│   ├── dist
-│ │ └── v7.6.2
-│   │       ├── conf
-│ │ └── lib
-│   └── plugin
-│ └── 7.6.2
+│   ├── dist
+│   │   └── 7.6.2
+│   │       ├── conf
+│   │       └── lib
+│   └── plugin
+│       └── 7.6.2
 ```
 ### 2.3 Engine refresh
 

--- a/docs/engine-usage/flink.md
+++ b/docs/engine-usage/flink.md
@@ -60,13 +60,13 @@ ${LINKIS_HOME}/lib/linkis-engineplugins
 The directory structure after uploading is as follows
 ```
 linkis-engineconn-plugins/
-├── big
-│   ├── dist
-│ │ └── v1.12.2
-│   │       ├── conf
-│ │ └── lib
-│   └── plugin
-│ └── 1.12.2
+├── flink
+│   ├── dist
+│   │   └── 1.12.2
+│   │       ├── conf
+│   │       └── lib
+│   └── plugin
+│       └── 1.12.2
 ```
 ### 2.3 Engine refresh
 

--- a/docs/engine-usage/jdbc.md
+++ b/docs/engine-usage/jdbc.md
@@ -62,12 +62,12 @@ The directory structure after uploading is as follows
 ```
 linkis-engineconn-plugins/
 ├── jdbc
-│   ├── dist
-│ │ └── v4
-│   │       ├── conf
-│ │ └── lib
-│   └── plugin
-│ └── 4
+│   ├── dist
+│   │   └── 4
+│   │       ├── conf
+│   │       └── lib
+│   └── plugin
+│       └── 4
 ```
 
 ### 2.3 Engine refresh

--- a/docs/engine-usage/openlookeng.md
+++ b/docs/engine-usage/openlookeng.md
@@ -69,12 +69,12 @@ The directory structure after uploading is as follows
 ```
 linkis-engineconn-plugins/
 ├── openlookeng
-│   ├── dist
-│ │ └── v1.5.0
-│   │       ├── conf
-│ │ └── lib
-│   └── plugin
-│ └── 1.5.0
+│   ├── dist
+│   │   └── 1.5.0
+│   │       ├── conf
+│   │       └── lib
+│   └── plugin
+│       └── 1.5.0
 ```
 
 ### 2.3 Engine refresh

--- a/docs/engine-usage/pipeline.md
+++ b/docs/engine-usage/pipeline.md
@@ -33,12 +33,12 @@ The directory structure after uploading is as follows
 ```
 linkis-engineconn-plugins/
 ├── pipeline
-│   ├── dist
-│ │ └── v1
-│   │       ├── conf
-│ │ └── lib
-│   └── plugin
-│ └── 1
+│   ├── dist
+│   │   └── 1
+│   │       ├── conf
+│   │       └── lib
+│   └── plugin
+│       └── 1
 ```
 ### 1.3 Engine refresh
 

--- a/docs/engine-usage/presto.md
+++ b/docs/engine-usage/presto.md
@@ -69,11 +69,11 @@ The directory structure after uploading is as follows
 linkis-engineconn-plugins/
 ├── soon
 │   ├── dist
-│ │ └── v0.234
-│   │       ├── conf
-│ │ └── lib
+│   │   └── 0.234
+│           ├── conf
+│   │       └── lib
 │   └── plugin
-│ └── 0.234
+│       └── 0.234
 ```
 
 ### 2.3 Engine refresh

--- a/docs/engine-usage/seatunnel.md
+++ b/docs/engine-usage/seatunnel.md
@@ -68,11 +68,11 @@ The directory structure after uploading is as follows
 linkis-engineconn-plugins/
 ├── seat tunnel
 │ ├── dist
-│ │ └── v2.1.2
-│ │ ├── conf
-│ │ └── lib
+│ │ └── 2.1.2
+│ │     ├── conf
+│ │     └── lib
 │ └── plugin
-│ └── 2.1.2
+│   └── 2.1.2
 ```
 
 ### 2.3 Engine refresh

--- a/docs/engine-usage/sqoop.md
+++ b/docs/engine-usage/sqoop.md
@@ -74,11 +74,11 @@ The directory structure after uploading is as follows
 linkis-engineconn-plugins/
 ├── sqoop
 │ ├── dist
-│ │ └── v1.4.6
-│ │ ├── conf
-│ │ └── lib
+│ │ └── 1.4.6
+│ │     ├── conf
+│ │     └── lib
 │ └── plugin
-│ └── 1.4.6
+│   └── 1.4.6
 ```
 
 ### 2.3 Engine refresh

--- a/docs/engine-usage/trino.md
+++ b/docs/engine-usage/trino.md
@@ -67,13 +67,13 @@ ${LINKIS_HOME}/lib/linkis-engineplugins
 The directory structure after uploading is as follows
 ```
 linkis-engineconn-plugins/
-├── triune
-│   ├── dist
-│ │ └── v371
-│   │       ├── conf
-│ │ └── lib
-│   └── plugin
-│ └── 371
+├── trino
+│   ├── dist
+│   │   └── 371
+│   │       ├── conf
+│   │       └── lib
+│   └── plugin
+│       └── 371
 ```
 
 ### 2.3 Engine refresh

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/deployment/deploy-quick.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/deployment/deploy-quick.md
@@ -446,17 +446,17 @@ linkis-package/lib/linkis-engineconn-plugins/
 │       └── 2.3.3
 ├── python
 │   ├── dist
-│   │   └── vpython2
+│   │   └── python2
 │   └── plugin
 │       └── python2 #版本为python2 engineType 为python-python2
 ├── shell
 │   ├── dist
-│   │   └── v1
+│   │   └── 1
 │   └── plugin
 │       └── 1
 └── spark
     ├── dist
-    │   └── v2.4.3
+    │   └── 2.4.3
     └── plugin
         └── 2.4.3
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/deployment/install-engineconn.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/deployment/install-engineconn.md
@@ -20,7 +20,7 @@ hive #引擎主目录，必须为引擎的名字
 │           └── linkis-engineplugin-hive-1.0.0.jar  #引擎模块包（只需要放置单独的引擎包）
 ├── python
 │   ├── dist
-│   │   └── vpython2
+│   │   └── python2
 │   └── plugin
 │       └── python2 #版本为python2 任务请求参数的engineTypee 为python-python2
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/engine-usage/elasticsearch.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/engine-usage/elasticsearch.md
@@ -66,7 +66,7 @@ ${LINKIS_HOME}/lib/linkis-engineplugins
 linkis-engineconn-plugins/
 ├── elasticsearch
 │   ├── dist
-│   │   └── v7.6.2
+│   │   └── 7.6.2
 │   │       ├── conf
 │   │       └── lib
 │   └── plugin

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/engine-usage/flink.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/engine-usage/flink.md
@@ -62,7 +62,7 @@ ${LINKIS_HOME}/lib/linkis-engineplugins
 linkis-engineconn-plugins/
 ├── flink
 │   ├── dist
-│   │   └── v1.12.2
+│   │   └── 1.12.2
 │   │       ├── conf
 │   │       └── lib
 │   └── plugin

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/engine-usage/jdbc.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/engine-usage/jdbc.md
@@ -63,7 +63,7 @@ ${LINKIS_HOME}/lib/linkis-engineplugins
 linkis-engineconn-plugins/
 ├── jdbc
 │   ├── dist
-│   │   └── v4
+│   │   └── 4
 │   │       ├── conf
 │   │       └── lib
 │   └── plugin

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/engine-usage/openlookeng.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/engine-usage/openlookeng.md
@@ -69,7 +69,7 @@ ${LINKIS_HOME}/lib/linkis-engineplugins
 linkis-engineconn-plugins/
 ├── openlookeng
 │   ├── dist
-│   │   └── v1.5.0
+│   │   └── 1.5.0
 │   │       ├── conf
 │   │       └── lib
 │   └── plugin

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/engine-usage/pipeline.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/engine-usage/pipeline.md
@@ -34,7 +34,7 @@ ${LINKIS_HOME}/lib/linkis-engineplugins
 linkis-engineconn-plugins/
 ├── pipeline
 │   ├── dist
-│   │   └── v1
+│   │   └── 1
 │   │       ├── conf
 │   │       └── lib
 │   └── plugin

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/engine-usage/presto.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/engine-usage/presto.md
@@ -69,7 +69,7 @@ ${LINKIS_HOME}/lib/linkis-engineplugins
 linkis-engineconn-plugins/
 ├── presto
 │   ├── dist
-│   │   └── v0.234
+│   │   └── 0.234
 │   │       ├── conf
 │   │       └── lib
 │   └── plugin

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/engine-usage/python.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/engine-usage/python.md
@@ -106,7 +106,7 @@ http 请求参数示例
 ```
 
 #### 4.2.3 文件配置
-通过修改目录 `${LINKIS_HOME}/lib/linkis-engineconn-plugins/python/dist/vpython2/conf/` 中的 `linkis-engineconn.properties` 文件进行配置，如下图：
+通过修改目录 `${LINKIS_HOME}/lib/linkis-engineconn-plugins/python/dist/python2/conf/` 中的 `linkis-engineconn.properties` 文件进行配置，如下图：
 
 ![](./images/python-conf.png)
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/engine-usage/seatunnel.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/engine-usage/seatunnel.md
@@ -68,7 +68,7 @@ ${LINKIS_HOME}/lib/linkis-engineplugins
 linkis-engineconn-plugins/
 ├── seatunnel
 │   ├── dist
-│   │   └── v2.1.2
+│   │   └── 2.1.2
 │   │       ├── conf
 │   │       └── lib
 │   └── plugin

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/engine-usage/sqoop.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/engine-usage/sqoop.md
@@ -69,12 +69,12 @@ ${linkis_code_dir}/linkis-engineconn-plugins/sqoop/target/out/
 ```bash 
 ${LINKIS_HOME}/lib/linkis-engineplugins
 ```
-上传后目录结构如下所示
+上传后目录结构如下所示:
 ```
 linkis-engineconn-plugins/
 ├── sqoop
 │   ├── dist
-│   │   └── v1.4.6
+│   │   └── 1.4.6
 │   │       ├── conf
 │   │       └── lib
 │   └── plugin

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/engine-usage/trino.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/engine-usage/trino.md
@@ -69,7 +69,7 @@ ${LINKIS_HOME}/lib/linkis-engineplugins
 linkis-engineconn-plugins/
 ├── trino
 │   ├── dist
-│   │   └── v371
+│   │   └── 371
 │   │       ├── conf
 │   │       └── lib
 │   └── plugin


### PR DESCRIPTION
**The version number prefix 'v' has been removed from the BOM due to iterative version updates**

![企业微信截图_16731894416842](https://user-images.githubusercontent.com/106590848/211202898-8f402835-7b0c-45ec-b6e4-f2e1ae724423.png)
