### PR TITLE
[feat] remove incubating

### DIFF
--- a/docs/deployment/deploy-quick.md
+++ b/docs/deployment/deploy-quick.md
@@ -46,23 +46,25 @@ hadoop ALL=(ALL) NOPASSWD: NOPASSWD: ALL
 , download the corresponding The installation package (project installation package and management console installation package)
 - Method 2: Compile the project installation package and management console according to [Linkis Compile and Package](../development/build) and [Front-end Management Console Compile](../development/build-console) Installation package
 
-After uploading the installation package `apache-linkis-x.x.x-incubating-bin.tar.gz`, decompress the installation package
+After uploading the installation package `apache-linkis-x.x.x-bin.tar.gz`, decompress the installation package
 
 ```shell script
-$ tar -xvf apache-linkis-x.x.x-incubating-bin.tar.gz
+$ tar -xvf apache-linkis-x.x.x-bin.tar.gz
 ````
 
 The unzipped directory structure is as follows
 ```shell script
--rw-r--r-- 1 hadoop hadoop 531847342 Feb 21 10:10 apache-linkis-1.0.3-incubating-bin.tar.gz
-drwxrwxr-x 2 hadoop hadoop 4096 Feb 21 10:13 bin //Script to perform environment check and install
-drwxrwxr-x 2 hadoop hadoop 4096 Feb 21 10:13 deploy-config // Environment configuration information such as DB that depends on deployment
--rw-r--r-- 1 hadoop hadoop 66058 Jan 22 2020 LICENSE
-drwxrwxr-x 2 hadoop hadoop 16384 Feb 21 10:13 licenses
-drwxrwxr-x 7 hadoop hadoop 4096 Feb 21 10:13 linkis-package // The actual package, including lib/service startup script tool/db initialization script/microservice configuration file, etc.
--rw-r--r-- 1 hadoop hadoop 83126 Jan 22 2020 NOTICE
--rw-r--r-- 1 hadoop hadoop 7900 Jan 22 2020 README_CN.md
--rw-r--r-- 1 hadoop hadoop 8184 Jan 22 2020 README.md
+-rw-r--r-- 1 hadoop hadoop 518192043 Jun 20 09:50 apache-linkis-1.3.1-bin.tar.gz
+drwxrwxr-x 2 hadoop hadoop      4096 Jun 20 09:56 bin //Script to perform environment check and install
+drwxrwxr-x 2 hadoop hadoop      4096 Jun 20 09:56 deploy-config // Environment configuration information such as DB that depends on deployment
+drwxrwxr-x 4 hadoop hadoop      4096 Jun 20 09:56 docker
+drwxrwxr-x 4 hadoop hadoop      4096 Jun 20 09:56 helm
+-rwxrwxr-x 1 hadoop hadoop     84732 Jan 22  2020 LICENSE
+drwxr-xr-x 2 hadoop hadoop     20480 Jun 20 09:56 licenses
+drwxrwxr-x 7 hadoop hadoop      4096 Jun 20 09:56 linkis-package // The actual package, including lib/service startup script tool/db initialization script/microservice configuration file, etc.
+-rwxrwxr-x 1 hadoop hadoop    119503 Jan 22  2020 NOTICE
+-rw-r--r-- 1 hadoop hadoop     11959 Jan 22  2020 README_CN.md
+-rw-r--r-- 1 hadoop hadoop     12587 Jan 22  2020 README.md
 
 ````
 

--- a/i18n/zh-CN/docusaurus-plugin-content-blog/2022-02-21-linkis-deploy.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-blog/2022-02-21-linkis-deploy.md
@@ -115,26 +115,25 @@ $ hive --version
 
 ## 2. 安裝
 ### 2.1 安装包解压
-上传安装包`apache-linkis-1.0.3-incubating-bin.tar.gz`后，进行解压安装包 
+上传安装包`apache-linkis-1.3.1-bin.tar.gz`后，进行解压安装包 
 
 ```shell script
-$ tar -xvf apache-linkis-1.0.3-incubating-bin.tar.gz
-$ pwd
-/data/Install/1.0.3
+$ tar -xvf apache-linkis-1.3.1-bin.tar.gz
 ```
 
 解压后的目录结构如下
 ```shell script
--rw-r--r-- 1 hadoop hadoop 531847342 Feb 21 10:10 apache-linkis-1.0.3-incubating-bin.tar.gz
-drwxrwxr-x 2 hadoop hadoop      4096 Feb 21 10:13 bin  //执行环境检查和安装的脚本
-drwxrwxr-x 2 hadoop hadoop      4096 Feb 21 10:13 deploy-config // 部署时依赖的DB等环境配置信息
--rw-r--r-- 1 hadoop hadoop      1707 Jan 22  2020 DISCLAIMER-WIP
--rw-r--r-- 1 hadoop hadoop     66058 Jan 22  2020 LICENSE
-drwxrwxr-x 2 hadoop hadoop     16384 Feb 21 10:13 licenses
-drwxrwxr-x 7 hadoop hadoop      4096 Feb 21 10:13 linkis-package // 实际的软件包，包括lib/服务启动脚本工具/db的初始化脚本/微服务的配置文件等
--rw-r--r-- 1 hadoop hadoop     83126 Jan 22  2020 NOTICE
--rw-r--r-- 1 hadoop hadoop      7900 Jan 22  2020 README_CN.md
--rw-r--r-- 1 hadoop hadoop      8184 Jan 22  2020 README.md
+-rw-r--r-- 1 hadoop hadoop 518192043 Jun 20 09:50 apache-linkis-1.3.1-bin.tar.gz
+drwxrwxr-x 2 hadoop hadoop      4096 Jun 20 09:56 bin  //执行环境检查和安装的脚本
+drwxrwxr-x 2 hadoop hadoop      4096 Jun 20 09:56 deploy-config // 部署时依赖的DB等环境配置信息
+drwxrwxr-x 4 hadoop hadoop      4096 Jun 20 09:56 docker
+drwxrwxr-x 4 hadoop hadoop      4096 Jun 20 09:56 helm
+-rwxrwxr-x 1 hadoop hadoop     84732 Jan 22  2020 LICENSE
+drwxr-xr-x 2 hadoop hadoop     20480 Jun 20 09:56 licenses
+drwxrwxr-x 7 hadoop hadoop      4096 Jun 20 09:56 linkis-package // 实际的软件包，包括lib/服务启动脚本工具/db的初始化脚本/微服务的配置文件等
+-rwxrwxr-x 1 hadoop hadoop    119503 Jan 22  2020 NOTICE
+-rw-r--r-- 1 hadoop hadoop     11959 Jan 22  2020 README_CN.md
+-rw-r--r-- 1 hadoop hadoop     12587 Jan 22  2020 README.md
 
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs-download/current/main.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs-download/current/main.md
@@ -44,9 +44,9 @@ $ sha512sum --check  apache-linkis-xxxxx-src.tar.gz.sha512
 如果是下载版本的Source源码包，可以按下面简易步骤，进行编译
 
 ```shell script
-$ tar -xvf apache-linkis-xxxxx-incubating-src.tar.gz
+$ tar -xvf apache-linkis-xxxxx-src.tar.gz
 
-$ cd apache-linkis-xxxxx-incubating-src
+$ cd apache-linkis-xxxxx-src
 
 #如果本源码包是首次编译，需要执行本命令，一般执行在3分钟内完成
 $ ./mvnw -N install

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/deployment/deploy-console.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/deployment/deploy-console.md
@@ -10,8 +10,8 @@ Linkis 提供了单独的前端管理台功能，提供了展示历史任务的�
 
 ## 1 准备工作
 
-1. 从linkis的release页面（[点击这里进入下载页面](https://linkis.apache.org/zh-CN/download/main)）下载web安装包`apache-linkis-x.x.x-incubating-web-bin.tar.gz`
-手动解压：`tar -xvf  apache-linkis-x.x.x-incubating-web-bin.tar.gz`，
+1. 从linkis的release页面（[点击这里进入下载页面](https://linkis.apache.org/zh-CN/download/main)）下载web安装包`apache-linkis-x.x.x-web-bin.tar.gz`
+手动解压：`tar -xvf  apache-linkis-x.x.x-web-bin.tar.gz`，
 
 解压后目录为：
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/deployment/deploy-quick.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/deployment/deploy-quick.md
@@ -46,23 +46,25 @@ hadoop ALL=(ALL) NOPASSWD: NOPASSWD: ALL
 ，下载对应的安装包（项目安装包和管理台安装包）。
 - 方式2：根据[Linkis 编译打包](../development/build)和[前端管理台编译](../development/build-console) 自行编译出项目安装包和管理台安装包。
 
-上传安装包`apache-linkis-x.x.x-incubating-bin.tar.gz`后，进行解压安装包 
+上传安装包`apache-linkis-x.x.x-bin.tar.gz`后，进行解压安装包 
 
 ```shell script
-$ tar -xvf apache-linkis-x.x.x-incubating-bin.tar.gz
+$ tar -xvf apache-linkis-x.x.x-bin.tar.gz
 ```
 
 解压后的目录结构如下
 ```shell script
--rw-r--r-- 1 hadoop hadoop 531847342 Feb 21 10:10 apache-linkis-1.0.3-incubating-bin.tar.gz
-drwxrwxr-x 2 hadoop hadoop      4096 Feb 21 10:13 bin  //执行环境检查和安装的脚本
-drwxrwxr-x 2 hadoop hadoop      4096 Feb 21 10:13 deploy-config // 部署时依赖的DB等环境配置信息
--rw-r--r-- 1 hadoop hadoop     66058 Jan 22  2020 LICENSE
-drwxrwxr-x 2 hadoop hadoop     16384 Feb 21 10:13 licenses
-drwxrwxr-x 7 hadoop hadoop      4096 Feb 21 10:13 linkis-package // 实际的软件包，包括lib/服务启动脚本工具/db的初始化脚本/微服务的配置文件等
--rw-r--r-- 1 hadoop hadoop     83126 Jan 22  2020 NOTICE
--rw-r--r-- 1 hadoop hadoop      7900 Jan 22  2020 README_CN.md
--rw-r--r-- 1 hadoop hadoop      8184 Jan 22  2020 README.md
+-rw-r--r-- 1 hadoop hadoop 518192043 Jun 20 09:50 apache-linkis-1.3.1-bin.tar.gz
+drwxrwxr-x 2 hadoop hadoop      4096 Jun 20 09:56 bin  //执行环境检查和安装的脚本
+drwxrwxr-x 2 hadoop hadoop      4096 Jun 20 09:56 deploy-config // 部署时依赖的DB等环境配置信息
+drwxrwxr-x 4 hadoop hadoop      4096 Jun 20 09:56 docker
+drwxrwxr-x 4 hadoop hadoop      4096 Jun 20 09:56 helm
+-rwxrwxr-x 1 hadoop hadoop     84732 Jan 22  2020 LICENSE
+drwxr-xr-x 2 hadoop hadoop     20480 Jun 20 09:56 licenses
+drwxrwxr-x 7 hadoop hadoop      4096 Jun 20 09:56 linkis-package // 实际的软件包，包括lib/服务启动脚本工具/db的初始化脚本/微服务的配置文件等
+-rwxrwxr-x 1 hadoop hadoop    119503 Jan 22  2020 NOTICE
+-rw-r--r-- 1 hadoop hadoop     11959 Jan 22  2020 README_CN.md
+-rw-r--r-- 1 hadoop hadoop     12587 Jan 22  2020 README.md
 
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/deployment/deploy-quick.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/deployment/deploy-quick.md
@@ -357,7 +357,7 @@ web端是使用nginx作为静态资源服务器的，访问请求流程是:
 
 ### 4.1 下载前端安装包并解压
 ```shell script
-tar -xvf apache-linkis-x.x.x-incubating-web-bin.tar.gz
+tar -xvf apache-linkis-x.x.x-web-bin.tar.gz
 ```
 
 ### 4.2 修改配置config.sh
@@ -644,7 +644,7 @@ sh -x engineConnExec.sh
 
 1.执行安装之前修改注册中心eureka端口
 ```
-1. 进入apache-linkis-x.x.x-incubating-bin.tar.gz的解压目录
+1. 进入apache-linkis-x.x.x-bin.tar.gz的解压目录
 2. 执行 vi deploy-config/linkis-env.sh
 3. 修改EUREKA_PORT=20303为EUREKA_PORT=端口号
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/development/build-console.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/development/build-console.md
@@ -38,7 +38,7 @@ $ npm install
 ```
 $ npm run build
 ```
-上述命令执行成功后，会生成前端管理台安装包 `apache-linkis-${version}-incubating-web-bin.tar.gz`，可以直接将该文件夹放进您的静态服务器中，或者参考[安装文档](../deployment/deploy-console.md)，使用脚本进行部署安装。
+上述命令执行成功后，会生成前端管理台安装包 `apache-linkis-${version}-web-bin.tar.gz`，可以直接将该文件夹放进您的静态服务器中，或者参考[安装文档](../deployment/deploy-console.md)，使用脚本进行部署安装。
 
 ## 3 . 注意事项
 ### 3.1 Windows下npm install 步骤报错

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/development/build.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/development/build.md
@@ -56,7 +56,7 @@ __编译环境要求：__  必须 **JDK8** 以上，**Oracle/Sun** 和 **OpenJDK
 
 ```bash
     #详细路径如下
-    linkis-x.x.x/linkis-dist/target/apache-linkis-x.x.x-incubating-bin.tar.gz
+    linkis-x.x.x/linkis-dist/target/apache-linkis-x.x.x-bin.tar.gz
 ```
 
 ## 3 常见问题 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/development/debug.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/development/debug.md
@@ -29,7 +29,7 @@ mvn -N install
 mvn clean install -DskipTests
 ```
 
-编译命令运行成功之后，在目录linkis/linkis-dist/target/下可找到编译好的安装包：apache-linkis-版本号-incubating-bin.tar.gz
+编译命令运行成功之后，在目录linkis/linkis-dist/target/下可找到编译好的安装包：apache-linkis-版本号-bin.tar.gz
 
 ## 3. 配置并启动服务
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/development/development-specification/license.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/development/development-specification/license.md
@@ -77,7 +77,7 @@ copyright notice that is included in or attached to the work.
 
 ### 2.2 示例 场景 2
 
-项目编译依赖了`org.apache.ant:ant:1.9.1`,ant-1.9.1.jar会在最后的编译安装包`target/apache-linkis-x.x.x-incubating-bin/linkis-package/lib`中
+项目编译依赖了`org.apache.ant:ant:1.9.1`,ant-1.9.1.jar会在最后的编译安装包`target/apache-linkis-x.x.x-bin/linkis-package/lib`中
 可以解压ant-1.9.1.jar，从jar包中提取LICENSE/NOTICE文件，如果没有，则需要找到对应的版本源码 
 找到py4j-0.10.7-src.zip 对应的版本源码分支，如果对应版本分支没有，则选择主分支
 - 项目源码位于:https://github.com/apache/ant/tree/rel/1.9.1

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/development/new-engine-conn.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/development/new-engine-conn.md
@@ -203,7 +203,7 @@ linkis-dist/src/main/assembly/distribution.xml
 mvn clean install -DskipTests
 ```
 
-编译成功后在linkis-dist/target/apache-linkis-1.x.x-incubating-bin.tar.gz和linkis-engineconn-plugins/jdbc/target/目录下找到out.zip。
+编译成功后在linkis-dist/target/apache-linkis-1.x.x-bin.tar.gz和linkis-engineconn-plugins/jdbc/target/目录下找到out.zip。
 
 上传out.zip文件到Linkis的部署节点，解压缩到Linkis安装目录/lib/linkis-engineconn-plugins/下面：
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/development/new-microservice.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/development/new-microservice.md
@@ -232,7 +232,7 @@ org.apache.linkis.newmicroservice.server.LinkisNewmicroserviceApplication
 
 ## 2. 打包部署
 > 打包部署主要有有两个阶段 第一步是模块通过maven打包后 会将模块所需要的依赖 打包到模块对应的target目录下 linkis-new-microservice/target/out/lib。
-> 第二步是 组装完整的最终部署安装包时，需要将` linkis-new-microservice/target/out/lib` 自动拷贝至 `linkis-dist/target/apache-linkis-x.x.x-incubating-bin/linkis-package/lib`下
+> 第二步是 组装完整的最终部署安装包时，需要将` linkis-new-microservice/target/out/lib` 自动拷贝至 `linkis-dist/target/apache-linkis-x.x.x-bin/linkis-package/lib`下
 
 ### 2.1 修改新服务下的distribution.xml
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/quick/deploy-to-kubernetes.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/quick/deploy-to-kubernetes.md
@@ -54,7 +54,7 @@ mv kind-linux-amd64 /usr/bin/kind
 ### 4.1 下载或自行编译 linkis1.3.1 部署包
 使用版本：dev-1.3.1 分支编译版本
 ```
-apache-linkis-1.3.1-incubating-bin.tar.gz
+apache-linkis-1.3.1-bin.tar.gz
 ```
 ### 4.2 创建目录
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/upgrade/upgrade-guide.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/upgrade/upgrade-guide.md
@@ -126,7 +126,7 @@ cp ${LINKIS_HOME_OLD}/lib/linkis-spring-cloud-services/linkis-mg-gateway/dss-gat
 ### 5.1 下载前端安装包并解压
 上传至管理台所在的服务器上 ，解压
 ```shell script
-tar -xvf apache-linkis-x.x.x-incubating-web-bin.tar.gz
+tar -xvf apache-linkis-x.x.x-web-bin.tar.gz
 ```
 
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.1/current/deployment/deploy-console.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.1/current/deployment/deploy-console.md
@@ -10,8 +10,8 @@ Linkis 提供了单独的前端管理台功能，提供了展示历史任务的�
 
 ## 1 准备工作
 
-1. 从linkis的release页面（[点击这里进入下载页面](https://linkis.apache.org/zh-CN/download/main)）下载web安装包`apache-linkis-x.x.x-incubating-web-bin.tar.gz`
-手动解压：`tar -xvf  apache-linkis-x.x.x-incubating-web-bin.tar.gz`，
+1. 从linkis的release页面（[点击这里进入下载页面](https://linkis.apache.org/zh-CN/download/main)）下载web安装包`apache-linkis-x.x.x-web-bin.tar.gz`
+手动解压：`tar -xvf  apache-linkis-x.x.x-web-bin.tar.gz`，
 
 解压后目录为：
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.1/current/deployment/deploy-quick.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.1/current/deployment/deploy-quick.md
@@ -46,24 +46,25 @@ hadoop ALL=(ALL) NOPASSWD: NOPASSWD: ALL
 ，下载对应的安装包（项目安装包和管理台安装包）。
 - 方式2：根据[Linkis 编译打包](../development/build)和[前端管理台编译](../development/build-console) 自行编译出项目安装包和管理台安装包。
 
-上传安装包`apache-linkis-x.x.x-incubating-bin.tar.gz`后，进行解压安装包 
+上传安装包`apache-linkis-x.x.x-bin.tar.gz`后，进行解压安装包 
 
 ```shell script
-$ tar -xvf apache-linkis-x.x.x-incubating-bin.tar.gz
+$ tar -xvf apache-linkis-x.x.x-bin.tar.gz
 ```
 
 解压后的目录结构如下
 ```shell script
--rw-r--r-- 1 hadoop hadoop 531847342 Feb 21 10:10 apache-linkis-1.0.3-incubating-bin.tar.gz
-drwxrwxr-x 2 hadoop hadoop      4096 Feb 21 10:13 bin  //执行环境检查和安装的脚本
-drwxrwxr-x 2 hadoop hadoop      4096 Feb 21 10:13 deploy-config // 部署时依赖的DB等环境配置信息
--rw-r--r-- 1 hadoop hadoop     66058 Jan 22  2020 LICENSE
-drwxrwxr-x 2 hadoop hadoop     16384 Feb 21 10:13 licenses
-drwxrwxr-x 7 hadoop hadoop      4096 Feb 21 10:13 linkis-package // 实际的软件包，包括lib/服务启动脚本工具/db的初始化脚本/微服务的配置文件等
--rw-r--r-- 1 hadoop hadoop     83126 Jan 22  2020 NOTICE
--rw-r--r-- 1 hadoop hadoop      7900 Jan 22  2020 README_CN.md
--rw-r--r-- 1 hadoop hadoop      8184 Jan 22  2020 README.md
-
+-rw-r--r-- 1 hadoop hadoop 518192043 Jun 20 09:50 apache-linkis-1.3.1-bin.tar.gz
+drwxrwxr-x 2 hadoop hadoop      4096 Jun 20 09:56 bin  //执行环境检查和安装的脚本
+drwxrwxr-x 2 hadoop hadoop      4096 Jun 20 09:56 deploy-config // 部署时依赖的DB等环境配置信息
+drwxrwxr-x 4 hadoop hadoop      4096 Jun 20 09:56 docker
+drwxrwxr-x 4 hadoop hadoop      4096 Jun 20 09:56 helm
+-rwxrwxr-x 1 hadoop hadoop     84732 Jan 22  2020 LICENSE
+drwxr-xr-x 2 hadoop hadoop     20480 Jun 20 09:56 licenses
+drwxrwxr-x 7 hadoop hadoop      4096 Jun 20 09:56 linkis-package // 实际的软件包，包括lib/服务启动脚本工具/db的初始化脚本/微服务的配置文件等
+-rwxrwxr-x 1 hadoop hadoop    119503 Jan 22  2020 NOTICE
+-rw-r--r-- 1 hadoop hadoop     11959 Jan 22  2020 README_CN.md
+-rw-r--r-- 1 hadoop hadoop     12587 Jan 22  2020 README.md
 ```
 
 ### 2.2 配置数据库信息
@@ -297,7 +298,7 @@ web端是使用nginx作为静态资源服务器的，访问请求流程是:
 
 ### 4.1 下载前端安装包并解压
 ```shell script
-tar -xvf apache-linkis-x.x.x-incubating-web-bin.tar.gz
+tar -xvf apache-linkis-x.x.x-web-bin.tar.gz
 ```
 
 ### 4.2 修改配置config.sh
@@ -584,7 +585,7 @@ sh -x engineConnExec.sh
 
 1.执行安装之前修改注册中心eureka端口
 ```
-1. 进入apache-linkis-x.x.x-incubating-bin.tar.gz的解压目录
+1. 进入apache-linkis-x.x.x-bin.tar.gz的解压目录
 2. 执行 vi deploy-config/linkis-env.sh
 3. 修改EUREKA_PORT=20303为EUREKA_PORT=端口号
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.1/current/development/build-console.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.1/current/development/build-console.md
@@ -38,7 +38,7 @@ $ npm install
 ```
 $ npm run build
 ```
-上述命令执行成功后，会生成前端管理台安装包 `apache-linkis-${version}-incubating-web-bin.tar.gz`，可以直接将该文件夹放进您的静态服务器中，或者参考[安装文档](../deployment/deploy-console.md)，使用脚本进行部署安装。
+上述命令执行成功后，会生成前端管理台安装包 `apache-linkis-${version}-web-bin.tar.gz`，可以直接将该文件夹放进您的静态服务器中，或者参考[安装文档](../deployment/deploy-console.md)，使用脚本进行部署安装。
 
 ## 3 . 注意事项
 ### 3.1 Windows下npm install 步骤报错

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.1/current/development/build.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.1/current/development/build.md
@@ -56,7 +56,7 @@ __编译环境要求：__  必须 **JDK8** 以上，**Oracle/Sun** 和 **OpenJDK
 
 ```bash
     #详细路径如下
-    linkis-x.x.x/linkis-dist/target/apache-linkis-x.x.x-incubating-bin.tar.gz
+    linkis-x.x.x/linkis-dist/target/apache-linkis-x.x.x-bin.tar.gz
 ```
 
 ## 3 常见问题 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.1/current/development/debug.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.1/current/development/debug.md
@@ -29,7 +29,7 @@ mvn -N install
 mvn clean install -DskipTests
 ```
 
-编译命令运行成功之后，在目录linkis/linkis-dist/target/下可找到编译好的安装包：apache-linkis-版本号-incubating-bin.tar.gz
+编译命令运行成功之后，在目录linkis/linkis-dist/target/下可找到编译好的安装包：apache-linkis-版本号-bin.tar.gz
 
 ## 3. 配置并启动服务
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.1/current/development/development-specification/license.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.1/current/development/development-specification/license.md
@@ -77,7 +77,7 @@ copyright notice that is included in or attached to the work.
 
 ### 2.2 示例 场景 2
 
-项目编译依赖了`org.apache.ant:ant:1.9.1`,ant-1.9.1.jar会在最后的编译安装包`target/apache-linkis-x.x.x-incubating-bin/linkis-package/lib`中
+项目编译依赖了`org.apache.ant:ant:1.9.1`,ant-1.9.1.jar会在最后的编译安装包`target/apache-linkis-x.x.x-bin/linkis-package/lib`中
 可以解压ant-1.9.1.jar，从jar包中提取LICENSE/NOTICE文件，如果没有，则需要找到对应的版本源码 
 找到py4j-0.10.7-src.zip 对应的版本源码分支，如果对应版本分支没有，则选择主分支
 - 项目源码位于:https://github.com/apache/ant/tree/rel/1.9.1

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.1/current/development/new-engine-conn.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.1/current/development/new-engine-conn.md
@@ -203,7 +203,7 @@ linkis-dist/src/main/assembly/distribution.xml
 mvn clean install -DskipTests
 ```
 
-编译成功后在linkis-dist/target/apache-linkis-1.x.x-incubating-bin.tar.gz和linkis-engineconn-plugins/jdbc/target/目录下找到out.zip。
+编译成功后在linkis-dist/target/apache-linkis-1.x.x-bin.tar.gz和linkis-engineconn-plugins/jdbc/target/目录下找到out.zip。
 
 上传out.zip文件到Linkis的部署节点，解压缩到Linkis安装目录/lib/linkis-engineconn-plugins/下面：
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.1/current/development/new-microservice.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.1/current/development/new-microservice.md
@@ -232,7 +232,7 @@ org.apache.linkis.newmicroservice.server.LinkisNewmicroserviceApplication
 
 ## 2. 打包部署
 > 打包部署主要有有两个阶段 第一步是模块通过maven打包后 会将模块所需要的依赖 打包到模块对应的target目录下 linkis-new-microservice/target/out/lib。
-> 第二步是 组装完整的最终部署安装包时，需要将` linkis-new-microservice/target/out/lib` 自动拷贝至 `linkis-dist/target/apache-linkis-x.x.x-incubating-bin/linkis-package/lib`下
+> 第二步是 组装完整的最终部署安装包时，需要将` linkis-new-microservice/target/out/lib` 自动拷贝至 `linkis-dist/target/apache-linkis-x.x.x-bin/linkis-package/lib`下
 
 ### 2.1 修改新服务下的distribution.xml
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.1/current/quick/deploy-to-kubernetes.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.1/current/quick/deploy-to-kubernetes.md
@@ -54,7 +54,7 @@ mv kind-linux-amd64 /usr/bin/kind
 ### 4.1 下载或自行编译 linkis1.3.1 部署包
 使用版本：dev-1.3.1 分支编译版本
 ```
-apache-linkis-1.3.1-incubating-bin.tar.gz
+apache-linkis-1.3.1-bin.tar.gz
 ```
 ### 4.2 创建目录
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.1/current/upgrade/upgrade-guide.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.1/current/upgrade/upgrade-guide.md
@@ -126,7 +126,7 @@ cp ${LINKIS_HOME_OLD}/lib/linkis-spring-cloud-services/linkis-mg-gateway/dss-gat
 ### 5.1 下载前端安装包并解压
 上传至管理台所在的服务器上 ，解压
 ```shell script
-tar -xvf apache-linkis-x.x.x-incubating-web-bin.tar.gz
+tar -xvf apache-linkis-x.x.x-web-bin.tar.gz
 ```
 
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.1/deployment/deploy-console.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.1/deployment/deploy-console.md
@@ -10,8 +10,8 @@ Linkis 提供了单独的前端管理台功能，提供了展示历史任务的�
 
 ## 1 准备工作
 
-1. 从linkis的release页面（[点击这里进入下载页面](https://linkis.apache.org/zh-CN/download/main)）下载web安装包`apache-linkis-x.x.x-incubating-web-bin.tar.gz`
-手动解压：`tar -xvf  apache-linkis-x.x.x-incubating-web-bin.tar.gz`，
+1. 从linkis的release页面（[点击这里进入下载页面](https://linkis.apache.org/zh-CN/download/main)）下载web安装包`apache-linkis-x.x.x-web-bin.tar.gz`
+手动解压：`tar -xvf  apache-linkis-x.x.x-web-bin.tar.gz`，
 
 解压后目录为：
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.1/deployment/deploy-quick.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.1/deployment/deploy-quick.md
@@ -46,23 +46,25 @@ hadoop ALL=(ALL) NOPASSWD: NOPASSWD: ALL
 ，下载对应的安装包（项目安装包和管理台安装包）。
 - 方式2：根据[Linkis 编译打包](../development/build)和[前端管理台编译](../development/build-console) 自行编译出项目安装包和管理台安装包。
 
-上传安装包`apache-linkis-x.x.x-incubating-bin.tar.gz`后，进行解压安装包 
+上传安装包`apache-linkis-x.x.x-bin.tar.gz`后，进行解压安装包 
 
 ```shell script
-$ tar -xvf apache-linkis-x.x.x-incubating-bin.tar.gz
+$ tar -xvf apache-linkis-x.x.x-bin.tar.gz
 ```
 
 解压后的目录结构如下
 ```shell script
--rw-r--r-- 1 hadoop hadoop 531847342 Feb 21 10:10 apache-linkis-1.0.3-incubating-bin.tar.gz
-drwxrwxr-x 2 hadoop hadoop      4096 Feb 21 10:13 bin  //执行环境检查和安装的脚本
-drwxrwxr-x 2 hadoop hadoop      4096 Feb 21 10:13 deploy-config // 部署时依赖的DB等环境配置信息
--rw-r--r-- 1 hadoop hadoop     66058 Jan 22  2020 LICENSE
-drwxrwxr-x 2 hadoop hadoop     16384 Feb 21 10:13 licenses
-drwxrwxr-x 7 hadoop hadoop      4096 Feb 21 10:13 linkis-package // 实际的软件包，包括lib/服务启动脚本工具/db的初始化脚本/微服务的配置文件等
--rw-r--r-- 1 hadoop hadoop     83126 Jan 22  2020 NOTICE
--rw-r--r-- 1 hadoop hadoop      7900 Jan 22  2020 README_CN.md
--rw-r--r-- 1 hadoop hadoop      8184 Jan 22  2020 README.md
+-rw-r--r-- 1 hadoop hadoop 518192043 Jun 20 09:50 apache-linkis-1.3.1-bin.tar.gz
+drwxrwxr-x 2 hadoop hadoop      4096 Jun 20 09:56 bin  //执行环境检查和安装的脚本
+drwxrwxr-x 2 hadoop hadoop      4096 Jun 20 09:56 deploy-config // 部署时依赖的DB等环境配置信息
+drwxrwxr-x 4 hadoop hadoop      4096 Jun 20 09:56 docker
+drwxrwxr-x 4 hadoop hadoop      4096 Jun 20 09:56 helm
+-rwxrwxr-x 1 hadoop hadoop     84732 Jan 22  2020 LICENSE
+drwxr-xr-x 2 hadoop hadoop     20480 Jun 20 09:56 licenses
+drwxrwxr-x 7 hadoop hadoop      4096 Jun 20 09:56 linkis-package // 实际的软件包，包括lib/服务启动脚本工具/db的初始化脚本/微服务的配置文件等
+-rwxrwxr-x 1 hadoop hadoop    119503 Jan 22  2020 NOTICE
+-rw-r--r-- 1 hadoop hadoop     11959 Jan 22  2020 README_CN.md
+-rw-r--r-- 1 hadoop hadoop     12587 Jan 22  2020 README.md
 
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.1/deployment/deploy-quick.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.1/deployment/deploy-quick.md
@@ -299,7 +299,7 @@ web端是使用nginx作为静态资源服务器的，访问请求流程是:
 
 ### 4.1 下载前端安装包并解压
 ```shell script
-tar -xvf apache-linkis-x.x.x-incubating-web-bin.tar.gz
+tar -xvf apache-linkis-x.x.x-web-bin.tar.gz
 ```
 
 ### 4.2 修改配置config.sh
@@ -586,7 +586,7 @@ sh -x engineConnExec.sh
 
 1.执行安装之前修改注册中心eureka端口
 ```
-1. 进入apache-linkis-x.x.x-incubating-bin.tar.gz的解压目录
+1. 进入apache-linkis-x.x.x-bin.tar.gz的解压目录
 2. 执行 vi deploy-config/linkis-env.sh
 3. 修改EUREKA_PORT=20303为EUREKA_PORT=端口号
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.1/development/build-console.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.1/development/build-console.md
@@ -38,7 +38,7 @@ $ npm install
 ```
 $ npm run build
 ```
-上述命令执行成功后，会生成前端管理台安装包 `apache-linkis-${version}-incubating-web-bin.tar.gz`，可以直接将该文件夹放进您的静态服务器中，或者参考[安装文档](../deployment/deploy-console.md)，使用脚本进行部署安装。
+上述命令执行成功后，会生成前端管理台安装包 `apache-linkis-${version}-web-bin.tar.gz`，可以直接将该文件夹放进您的静态服务器中，或者参考[安装文档](../deployment/deploy-console.md)，使用脚本进行部署安装。
 
 ## 3 . 注意事项
 ### 3.1 Windows下npm install 步骤报错

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.1/development/build.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.1/development/build.md
@@ -56,7 +56,7 @@ __编译环境要求：__  必须 **JDK8** 以上，**Oracle/Sun** 和 **OpenJDK
 
 ```bash
     #详细路径如下
-    linkis-x.x.x/linkis-dist/target/apache-linkis-x.x.x-incubating-bin.tar.gz
+    linkis-x.x.x/linkis-dist/target/apache-linkis-x.x.x-bin.tar.gz
 ```
 
 ## 3 常见问题 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.1/development/debug.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.1/development/debug.md
@@ -29,7 +29,7 @@ mvn -N install
 mvn clean install -DskipTests
 ```
 
-编译命令运行成功之后，在目录linkis/linkis-dist/target/下可找到编译好的安装包：apache-linkis-版本号-incubating-bin.tar.gz
+编译命令运行成功之后，在目录linkis/linkis-dist/target/下可找到编译好的安装包：apache-linkis-版本号-bin.tar.gz
 
 ## 3. 配置并启动服务
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.1/development/development-specification/license.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.1/development/development-specification/license.md
@@ -77,7 +77,7 @@ copyright notice that is included in or attached to the work.
 
 ### 2.2 示例 场景 2
 
-项目编译依赖了`org.apache.ant:ant:1.9.1`,ant-1.9.1.jar会在最后的编译安装包`target/apache-linkis-x.x.x-incubating-bin/linkis-package/lib`中
+项目编译依赖了`org.apache.ant:ant:1.9.1`,ant-1.9.1.jar会在最后的编译安装包`target/apache-linkis-x.x.x-bin/linkis-package/lib`中
 可以解压ant-1.9.1.jar，从jar包中提取LICENSE/NOTICE文件，如果没有，则需要找到对应的版本源码 
 找到py4j-0.10.7-src.zip 对应的版本源码分支，如果对应版本分支没有，则选择主分支
 - 项目源码位于:https://github.com/apache/ant/tree/rel/1.9.1

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.1/development/new-engine-conn.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.1/development/new-engine-conn.md
@@ -203,7 +203,7 @@ linkis-dist/src/main/assembly/distribution.xml
 mvn clean install -DskipTests
 ```
 
-编译成功后在linkis-dist/target/apache-linkis-1.x.x-incubating-bin.tar.gz和linkis-engineconn-plugins/jdbc/target/目录下找到out.zip。
+编译成功后在linkis-dist/target/apache-linkis-1.x.x-bin.tar.gz和linkis-engineconn-plugins/jdbc/target/目录下找到out.zip。
 
 上传out.zip文件到Linkis的部署节点，解压缩到Linkis安装目录/lib/linkis-engineconn-plugins/下面：
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.1/development/new-microservice.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.1/development/new-microservice.md
@@ -232,7 +232,7 @@ org.apache.linkis.newmicroservice.server.LinkisNewmicroserviceApplication
 
 ## 2. 打包部署
 > 打包部署主要有有两个阶段 第一步是模块通过maven打包后 会将模块所需要的依赖 打包到模块对应的target目录下 linkis-new-microservice/target/out/lib。
-> 第二步是 组装完整的最终部署安装包时，需要将` linkis-new-microservice/target/out/lib` 自动拷贝至 `linkis-dist/target/apache-linkis-x.x.x-incubating-bin/linkis-package/lib`下
+> 第二步是 组装完整的最终部署安装包时，需要将` linkis-new-microservice/target/out/lib` 自动拷贝至 `linkis-dist/target/apache-linkis-x.x.x-bin/linkis-package/lib`下
 
 ### 2.1 修改新服务下的distribution.xml
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.1/quick/deploy-to-kubernetes.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.1/quick/deploy-to-kubernetes.md
@@ -54,7 +54,7 @@ mv kind-linux-amd64 /usr/bin/kind
 ### 4.1 下载或自行编译 linkis1.3.1 部署包
 使用版本：dev-1.3.1 分支编译版本
 ```
-apache-linkis-1.3.1-incubating-bin.tar.gz
+apache-linkis-1.3.1-bin.tar.gz
 ```
 ### 4.2 创建目录
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.1/upgrade/upgrade-guide.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.1/upgrade/upgrade-guide.md
@@ -126,7 +126,7 @@ cp ${LINKIS_HOME_OLD}/lib/linkis-spring-cloud-services/linkis-mg-gateway/dss-gat
 ### 5.1 下载前端安装包并解压
 上传至管理台所在的服务器上 ，解压
 ```shell script
-tar -xvf apache-linkis-x.x.x-incubating-web-bin.tar.gz
+tar -xvf apache-linkis-x.x.x-web-bin.tar.gz
 ```
 
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.2/current/deployment/deploy-console.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.2/current/deployment/deploy-console.md
@@ -10,8 +10,8 @@ Linkis 提供了单独的前端管理台功能，提供了展示历史任务的�
 
 ## 1 准备工作
 
-1. 从linkis的release页面（[点击这里进入下载页面](https://linkis.apache.org/zh-CN/download/main)）下载web安装包`apache-linkis-x.x.x-incubating-web-bin.tar.gz`
-手动解压：`tar -xvf  apache-linkis-x.x.x-incubating-web-bin.tar.gz`，
+1. 从linkis的release页面（[点击这里进入下载页面](https://linkis.apache.org/zh-CN/download/main)）下载web安装包`apache-linkis-x.x.x-web-bin.tar.gz`
+手动解压：`tar -xvf  apache-linkis-x.x.x-web-bin.tar.gz`，
 
 解压后目录为：
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.2/current/deployment/deploy-quick.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.2/current/deployment/deploy-quick.md
@@ -46,23 +46,25 @@ hadoop ALL=(ALL) NOPASSWD: NOPASSWD: ALL
 ，下载对应的安装包（项目安装包和管理台安装包）。
 - 方式2：根据[Linkis 编译打包](../development/build)和[前端管理台编译](../development/build-console) 自行编译出项目安装包和管理台安装包。
 
-上传安装包`apache-linkis-x.x.x-incubating-bin.tar.gz`后，进行解压安装包 
+上传安装包`apache-linkis-x.x.x-bin.tar.gz`后，进行解压安装包 
 
 ```shell script
-$ tar -xvf apache-linkis-x.x.x-incubating-bin.tar.gz
+$ tar -xvf apache-linkis-x.x.x-bin.tar.gz
 ```
 
 解压后的目录结构如下
 ```shell script
--rw-r--r-- 1 hadoop hadoop 531847342 Feb 21 10:10 apache-linkis-1.0.3-incubating-bin.tar.gz
-drwxrwxr-x 2 hadoop hadoop      4096 Feb 21 10:13 bin  //执行环境检查和安装的脚本
-drwxrwxr-x 2 hadoop hadoop      4096 Feb 21 10:13 deploy-config // 部署时依赖的DB等环境配置信息
--rw-r--r-- 1 hadoop hadoop     66058 Jan 22  2020 LICENSE
-drwxrwxr-x 2 hadoop hadoop     16384 Feb 21 10:13 licenses
-drwxrwxr-x 7 hadoop hadoop      4096 Feb 21 10:13 linkis-package // 实际的软件包，包括lib/服务启动脚本工具/db的初始化脚本/微服务的配置文件等
--rw-r--r-- 1 hadoop hadoop     83126 Jan 22  2020 NOTICE
--rw-r--r-- 1 hadoop hadoop      7900 Jan 22  2020 README_CN.md
--rw-r--r-- 1 hadoop hadoop      8184 Jan 22  2020 README.md
+-rw-r--r-- 1 hadoop hadoop 518192043 Jun 20 09:50 apache-linkis-1.3.1-bin.tar.gz
+drwxrwxr-x 2 hadoop hadoop      4096 Jun 20 09:56 bin  //执行环境检查和安装的脚本
+drwxrwxr-x 2 hadoop hadoop      4096 Jun 20 09:56 deploy-config // 部署时依赖的DB等环境配置信息
+drwxrwxr-x 4 hadoop hadoop      4096 Jun 20 09:56 docker
+drwxrwxr-x 4 hadoop hadoop      4096 Jun 20 09:56 helm
+-rwxrwxr-x 1 hadoop hadoop     84732 Jan 22  2020 LICENSE
+drwxr-xr-x 2 hadoop hadoop     20480 Jun 20 09:56 licenses
+drwxrwxr-x 7 hadoop hadoop      4096 Jun 20 09:56 linkis-package // 实际的软件包，包括lib/服务启动脚本工具/db的初始化脚本/微服务的配置文件等
+-rwxrwxr-x 1 hadoop hadoop    119503 Jan 22  2020 NOTICE
+-rw-r--r-- 1 hadoop hadoop     11959 Jan 22  2020 README_CN.md
+-rw-r--r-- 1 hadoop hadoop     12587 Jan 22  2020 README.md
 
 ```
 
@@ -355,7 +357,7 @@ web端是使用nginx作为静态资源服务器的，访问请求流程是:
 
 ### 4.1 下载前端安装包并解压
 ```shell script
-tar -xvf apache-linkis-x.x.x-incubating-web-bin.tar.gz
+tar -xvf apache-linkis-x.x.x-web-bin.tar.gz
 ```
 
 ### 4.2 修改配置config.sh
@@ -642,7 +644,7 @@ sh -x engineConnExec.sh
 
 1.执行安装之前修改注册中心eureka端口
 ```
-1. 进入apache-linkis-x.x.x-incubating-bin.tar.gz的解压目录
+1. 进入apache-linkis-x.x.x-bin.tar.gz的解压目录
 2. 执行 vi deploy-config/linkis-env.sh
 3. 修改EUREKA_PORT=20303为EUREKA_PORT=端口号
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.2/current/development/build-console.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.2/current/development/build-console.md
@@ -38,7 +38,7 @@ $ npm install
 ```
 $ npm run build
 ```
-上述命令执行成功后，会生成前端管理台安装包 `apache-linkis-${version}-incubating-web-bin.tar.gz`，可以直接将该文件夹放进您的静态服务器中，或者参考[安装文档](../deployment/deploy-console.md)，使用脚本进行部署安装。
+上述命令执行成功后，会生成前端管理台安装包 `apache-linkis-${version}-web-bin.tar.gz`，可以直接将该文件夹放进您的静态服务器中，或者参考[安装文档](../deployment/deploy-console.md)，使用脚本进行部署安装。
 
 ## 3 . 注意事项
 ### 3.1 Windows下npm install 步骤报错

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.2/current/development/build.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.2/current/development/build.md
@@ -56,7 +56,7 @@ __编译环境要求：__  必须 **JDK8** 以上，**Oracle/Sun** 和 **OpenJDK
 
 ```bash
     #详细路径如下
-    linkis-x.x.x/linkis-dist/target/apache-linkis-x.x.x-incubating-bin.tar.gz
+    linkis-x.x.x/linkis-dist/target/apache-linkis-x.x.x-bin.tar.gz
 ```
 
 ## 3 常见问题 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.2/current/development/debug.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.2/current/development/debug.md
@@ -29,7 +29,7 @@ mvn -N install
 mvn clean install -DskipTests
 ```
 
-编译命令运行成功之后，在目录linkis/linkis-dist/target/下可找到编译好的安装包：apache-linkis-版本号-incubating-bin.tar.gz
+编译命令运行成功之后，在目录linkis/linkis-dist/target/下可找到编译好的安装包：apache-linkis-版本号-bin.tar.gz
 
 ## 3. 配置并启动服务
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.2/current/development/development-specification/license.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.2/current/development/development-specification/license.md
@@ -77,7 +77,7 @@ copyright notice that is included in or attached to the work.
 
 ### 2.2 示例 场景 2
 
-项目编译依赖了`org.apache.ant:ant:1.9.1`,ant-1.9.1.jar会在最后的编译安装包`target/apache-linkis-x.x.x-incubating-bin/linkis-package/lib`中
+项目编译依赖了`org.apache.ant:ant:1.9.1`,ant-1.9.1.jar会在最后的编译安装包`target/apache-linkis-x.x.x-bin/linkis-package/lib`中
 可以解压ant-1.9.1.jar，从jar包中提取LICENSE/NOTICE文件，如果没有，则需要找到对应的版本源码 
 找到py4j-0.10.7-src.zip 对应的版本源码分支，如果对应版本分支没有，则选择主分支
 - 项目源码位于:https://github.com/apache/ant/tree/rel/1.9.1

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.2/current/development/new-engine-conn.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.2/current/development/new-engine-conn.md
@@ -203,7 +203,7 @@ linkis-dist/src/main/assembly/distribution.xml
 mvn clean install -DskipTests
 ```
 
-编译成功后在linkis-dist/target/apache-linkis-1.x.x-incubating-bin.tar.gz和linkis-engineconn-plugins/jdbc/target/目录下找到out.zip。
+编译成功后在linkis-dist/target/apache-linkis-1.x.x-bin.tar.gz和linkis-engineconn-plugins/jdbc/target/目录下找到out.zip。
 
 上传out.zip文件到Linkis的部署节点，解压缩到Linkis安装目录/lib/linkis-engineconn-plugins/下面：
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.2/current/development/new-microservice.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.2/current/development/new-microservice.md
@@ -232,7 +232,7 @@ org.apache.linkis.newmicroservice.server.LinkisNewmicroserviceApplication
 
 ## 2. 打包部署
 > 打包部署主要有有两个阶段 第一步是模块通过maven打包后 会将模块所需要的依赖 打包到模块对应的target目录下 linkis-new-microservice/target/out/lib。
-> 第二步是 组装完整的最终部署安装包时，需要将` linkis-new-microservice/target/out/lib` 自动拷贝至 `linkis-dist/target/apache-linkis-x.x.x-incubating-bin/linkis-package/lib`下
+> 第二步是 组装完整的最终部署安装包时，需要将` linkis-new-microservice/target/out/lib` 自动拷贝至 `linkis-dist/target/apache-linkis-x.x.x-bin/linkis-package/lib`下
 
 ### 2.1 修改新服务下的distribution.xml
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.2/current/quick/deploy-to-kubernetes.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.2/current/quick/deploy-to-kubernetes.md
@@ -54,7 +54,7 @@ mv kind-linux-amd64 /usr/bin/kind
 ### 4.1 下载或自行编译 linkis1.3.1 部署包
 使用版本：dev-1.3.1 分支编译版本
 ```
-apache-linkis-1.3.1-incubating-bin.tar.gz
+apache-linkis-1.3.1-bin.tar.gz
 ```
 ### 4.2 创建目录
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.2/current/upgrade/upgrade-guide.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.2/current/upgrade/upgrade-guide.md
@@ -126,7 +126,7 @@ cp ${LINKIS_HOME_OLD}/lib/linkis-spring-cloud-services/linkis-mg-gateway/dss-gat
 ### 5.1 下载前端安装包并解压
 上传至管理台所在的服务器上 ，解压
 ```shell script
-tar -xvf apache-linkis-x.x.x-incubating-web-bin.tar.gz
+tar -xvf apache-linkis-x.x.x-web-bin.tar.gz
 ```
 
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.2/deployment/deploy-console.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.2/deployment/deploy-console.md
@@ -10,8 +10,8 @@ Linkis 提供了单独的前端管理台功能，提供了展示历史任务的�
 
 ## 1 准备工作
 
-1. 从linkis的release页面（[点击这里进入下载页面](https://linkis.apache.org/zh-CN/download/main)）下载web安装包`apache-linkis-x.x.x-incubating-web-bin.tar.gz`
-手动解压：`tar -xvf  apache-linkis-x.x.x-incubating-web-bin.tar.gz`，
+1. 从linkis的release页面（[点击这里进入下载页面](https://linkis.apache.org/zh-CN/download/main)）下载web安装包`apache-linkis-x.x.x-web-bin.tar.gz`
+手动解压：`tar -xvf  apache-linkis-x.x.x-web-bin.tar.gz`，
 
 解压后目录为：
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.2/deployment/deploy-quick.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.2/deployment/deploy-quick.md
@@ -46,23 +46,25 @@ hadoop ALL=(ALL) NOPASSWD: NOPASSWD: ALL
 ，下载对应的安装包（项目安装包和管理台安装包）。
 - 方式2：根据[Linkis 编译打包](../development/build)和[前端管理台编译](../development/build-console) 自行编译出项目安装包和管理台安装包。
 
-上传安装包`apache-linkis-x.x.x-incubating-bin.tar.gz`后，进行解压安装包 
+上传安装包`apache-linkis-x.x.x-bin.tar.gz`后，进行解压安装包 
 
 ```shell script
-$ tar -xvf apache-linkis-x.x.x-incubating-bin.tar.gz
+$ tar -xvf apache-linkis-x.x.x-bin.tar.gz
 ```
 
 解压后的目录结构如下
 ```shell script
--rw-r--r-- 1 hadoop hadoop 531847342 Feb 21 10:10 apache-linkis-1.0.3-incubating-bin.tar.gz
-drwxrwxr-x 2 hadoop hadoop      4096 Feb 21 10:13 bin  //执行环境检查和安装的脚本
-drwxrwxr-x 2 hadoop hadoop      4096 Feb 21 10:13 deploy-config // 部署时依赖的DB等环境配置信息
--rw-r--r-- 1 hadoop hadoop     66058 Jan 22  2020 LICENSE
-drwxrwxr-x 2 hadoop hadoop     16384 Feb 21 10:13 licenses
-drwxrwxr-x 7 hadoop hadoop      4096 Feb 21 10:13 linkis-package // 实际的软件包，包括lib/服务启动脚本工具/db的初始化脚本/微服务的配置文件等
--rw-r--r-- 1 hadoop hadoop     83126 Jan 22  2020 NOTICE
--rw-r--r-- 1 hadoop hadoop      7900 Jan 22  2020 README_CN.md
--rw-r--r-- 1 hadoop hadoop      8184 Jan 22  2020 README.md
+-rw-r--r-- 1 hadoop hadoop 518192043 Jun 20 09:50 apache-linkis-1.3.1-bin.tar.gz
+drwxrwxr-x 2 hadoop hadoop      4096 Jun 20 09:56 bin  //执行环境检查和安装的脚本
+drwxrwxr-x 2 hadoop hadoop      4096 Jun 20 09:56 deploy-config // 部署时依赖的DB等环境配置信息
+drwxrwxr-x 4 hadoop hadoop      4096 Jun 20 09:56 docker
+drwxrwxr-x 4 hadoop hadoop      4096 Jun 20 09:56 helm
+-rwxrwxr-x 1 hadoop hadoop     84732 Jan 22  2020 LICENSE
+drwxr-xr-x 2 hadoop hadoop     20480 Jun 20 09:56 licenses
+drwxrwxr-x 7 hadoop hadoop      4096 Jun 20 09:56 linkis-package // 实际的软件包，包括lib/服务启动脚本工具/db的初始化脚本/微服务的配置文件等
+-rwxrwxr-x 1 hadoop hadoop    119503 Jan 22  2020 NOTICE
+-rw-r--r-- 1 hadoop hadoop     11959 Jan 22  2020 README_CN.md
+-rw-r--r-- 1 hadoop hadoop     12587 Jan 22  2020 README.md
 
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.2/deployment/deploy-quick.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.2/deployment/deploy-quick.md
@@ -357,7 +357,7 @@ web端是使用nginx作为静态资源服务器的，访问请求流程是:
 
 ### 4.1 下载前端安装包并解压
 ```shell script
-tar -xvf apache-linkis-x.x.x-incubating-web-bin.tar.gz
+tar -xvf apache-linkis-x.x.x-web-bin.tar.gz
 ```
 
 ### 4.2 修改配置config.sh
@@ -644,7 +644,7 @@ sh -x engineConnExec.sh
 
 1.执行安装之前修改注册中心eureka端口
 ```
-1. 进入apache-linkis-x.x.x-incubating-bin.tar.gz的解压目录
+1. 进入apache-linkis-x.x.x-bin.tar.gz的解压目录
 2. 执行 vi deploy-config/linkis-env.sh
 3. 修改EUREKA_PORT=20303为EUREKA_PORT=端口号
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.2/development/build-console.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.2/development/build-console.md
@@ -38,7 +38,7 @@ $ npm install
 ```
 $ npm run build
 ```
-上述命令执行成功后，会生成前端管理台安装包 `apache-linkis-${version}-incubating-web-bin.tar.gz`，可以直接将该文件夹放进您的静态服务器中，或者参考[安装文档](../deployment/deploy-console.md)，使用脚本进行部署安装。
+上述命令执行成功后，会生成前端管理台安装包 `apache-linkis-${version}-web-bin.tar.gz`，可以直接将该文件夹放进您的静态服务器中，或者参考[安装文档](../deployment/deploy-console.md)，使用脚本进行部署安装。
 
 ## 3 . 注意事项
 ### 3.1 Windows下npm install 步骤报错

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.2/development/build.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.2/development/build.md
@@ -56,7 +56,7 @@ __编译环境要求：__  必须 **JDK8** 以上，**Oracle/Sun** 和 **OpenJDK
 
 ```bash
     #详细路径如下
-    linkis-x.x.x/linkis-dist/target/apache-linkis-x.x.x-incubating-bin.tar.gz
+    linkis-x.x.x/linkis-dist/target/apache-linkis-x.x.x-bin.tar.gz
 ```
 
 ## 3 常见问题 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.2/development/debug.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.2/development/debug.md
@@ -29,7 +29,7 @@ mvn -N install
 mvn clean install -DskipTests
 ```
 
-编译命令运行成功之后，在目录linkis/linkis-dist/target/下可找到编译好的安装包：apache-linkis-版本号-incubating-bin.tar.gz
+编译命令运行成功之后，在目录linkis/linkis-dist/target/下可找到编译好的安装包：apache-linkis-版本号-bin.tar.gz
 
 ## 3. 配置并启动服务
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.2/development/development-specification/license.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.2/development/development-specification/license.md
@@ -77,7 +77,7 @@ copyright notice that is included in or attached to the work.
 
 ### 2.2 示例 场景 2
 
-项目编译依赖了`org.apache.ant:ant:1.9.1`,ant-1.9.1.jar会在最后的编译安装包`target/apache-linkis-x.x.x-incubating-bin/linkis-package/lib`中
+项目编译依赖了`org.apache.ant:ant:1.9.1`,ant-1.9.1.jar会在最后的编译安装包`target/apache-linkis-x.x.x-bin/linkis-package/lib`中
 可以解压ant-1.9.1.jar，从jar包中提取LICENSE/NOTICE文件，如果没有，则需要找到对应的版本源码 
 找到py4j-0.10.7-src.zip 对应的版本源码分支，如果对应版本分支没有，则选择主分支
 - 项目源码位于:https://github.com/apache/ant/tree/rel/1.9.1

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.2/development/new-engine-conn.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.2/development/new-engine-conn.md
@@ -203,7 +203,7 @@ linkis-dist/src/main/assembly/distribution.xml
 mvn clean install -DskipTests
 ```
 
-编译成功后在linkis-dist/target/apache-linkis-1.x.x-incubating-bin.tar.gz和linkis-engineconn-plugins/jdbc/target/目录下找到out.zip。
+编译成功后在linkis-dist/target/apache-linkis-1.x.x-bin.tar.gz和linkis-engineconn-plugins/jdbc/target/目录下找到out.zip。
 
 上传out.zip文件到Linkis的部署节点，解压缩到Linkis安装目录/lib/linkis-engineconn-plugins/下面：
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.2/development/new-microservice.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.2/development/new-microservice.md
@@ -232,7 +232,7 @@ org.apache.linkis.newmicroservice.server.LinkisNewmicroserviceApplication
 
 ## 2. 打包部署
 > 打包部署主要有有两个阶段 第一步是模块通过maven打包后 会将模块所需要的依赖 打包到模块对应的target目录下 linkis-new-microservice/target/out/lib。
-> 第二步是 组装完整的最终部署安装包时，需要将` linkis-new-microservice/target/out/lib` 自动拷贝至 `linkis-dist/target/apache-linkis-x.x.x-incubating-bin/linkis-package/lib`下
+> 第二步是 组装完整的最终部署安装包时，需要将` linkis-new-microservice/target/out/lib` 自动拷贝至 `linkis-dist/target/apache-linkis-x.x.x-bin/linkis-package/lib`下
 
 ### 2.1 修改新服务下的distribution.xml
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.2/quick/deploy-to-kubernetes.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.2/quick/deploy-to-kubernetes.md
@@ -54,7 +54,7 @@ mv kind-linux-amd64 /usr/bin/kind
 ### 4.1 下载或自行编译 linkis1.3.1 部署包
 使用版本：dev-1.3.1 分支编译版本
 ```
-apache-linkis-1.3.1-incubating-bin.tar.gz
+apache-linkis-1.3.1-bin.tar.gz
 ```
 ### 4.2 创建目录
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.2/upgrade/upgrade-guide.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.3.2/upgrade/upgrade-guide.md
@@ -126,7 +126,7 @@ cp ${LINKIS_HOME_OLD}/lib/linkis-spring-cloud-services/linkis-mg-gateway/dss-gat
 ### 5.1 下载前端安装包并解压
 上传至管理台所在的服务器上 ，解压
 ```shell script
-tar -xvf apache-linkis-x.x.x-incubating-web-bin.tar.gz
+tar -xvf apache-linkis-x.x.x-web-bin.tar.gz
 ```
 
 

--- a/versioned_docs/version-1.3.1/deployment/deploy-quick.md
+++ b/versioned_docs/version-1.3.1/deployment/deploy-quick.md
@@ -46,23 +46,25 @@ hadoop ALL=(ALL) NOPASSWD: NOPASSWD: ALL
 , download the corresponding The installation package (project installation package and management console installation package)
 - Method 2: Compile the project installation package and management console according to [Linkis Compile and Package](../development/build) and [Front-end Management Console Compile](../development/build-console) Installation package
 
-After uploading the installation package `apache-linkis-x.x.x-incubating-bin.tar.gz`, decompress the installation package
+After uploading the installation package `apache-linkis-x.x.x-bin.tar.gz`, decompress the installation package
 
 ```shell script
-$ tar -xvf apache-linkis-x.x.x-incubating-bin.tar.gz
+$ tar -xvf apache-linkis-x.x.x-bin.tar.gz
 ````
 
 The unzipped directory structure is as follows
 ```shell script
--rw-r--r-- 1 hadoop hadoop 531847342 Feb 21 10:10 apache-linkis-1.0.3-incubating-bin.tar.gz
-drwxrwxr-x 2 hadoop hadoop 4096 Feb 21 10:13 bin //Script to perform environment check and install
-drwxrwxr-x 2 hadoop hadoop 4096 Feb 21 10:13 deploy-config // Environment configuration information such as DB that depends on deployment
--rw-r--r-- 1 hadoop hadoop 66058 Jan 22 2020 LICENSE
-drwxrwxr-x 2 hadoop hadoop 16384 Feb 21 10:13 licenses
-drwxrwxr-x 7 hadoop hadoop 4096 Feb 21 10:13 linkis-package // The actual package, including lib/service startup script tool/db initialization script/microservice configuration file, etc.
--rw-r--r-- 1 hadoop hadoop 83126 Jan 22 2020 NOTICE
--rw-r--r-- 1 hadoop hadoop 7900 Jan 22 2020 README_CN.md
--rw-r--r-- 1 hadoop hadoop 8184 Jan 22 2020 README.md
+-rw-r--r-- 1 hadoop hadoop 518192043 Jun 20 09:50 apache-linkis-1.3.1-bin.tar.gz
+drwxrwxr-x 2 hadoop hadoop      4096 Jun 20 09:56 bin //Script to perform environment check and install
+drwxrwxr-x 2 hadoop hadoop      4096 Jun 20 09:56 deploy-config // Environment configuration information such as DB that depends on deployment
+drwxrwxr-x 4 hadoop hadoop      4096 Jun 20 09:56 docker
+drwxrwxr-x 4 hadoop hadoop      4096 Jun 20 09:56 helm
+-rwxrwxr-x 1 hadoop hadoop     84732 Jan 22  2020 LICENSE
+drwxr-xr-x 2 hadoop hadoop     20480 Jun 20 09:56 licenses
+drwxrwxr-x 7 hadoop hadoop      4096 Jun 20 09:56 linkis-package // The actual package, including lib/service startup script tool/db initialization script/microservice configuration file, etc.
+-rwxrwxr-x 1 hadoop hadoop    119503 Jan 22  2020 NOTICE
+-rw-r--r-- 1 hadoop hadoop     11959 Jan 22  2020 README_CN.md
+-rw-r--r-- 1 hadoop hadoop     12587 Jan 22  2020 README.md
 
 ````
 

--- a/versioned_docs/version-1.3.2/deployment/deploy-quick.md
+++ b/versioned_docs/version-1.3.2/deployment/deploy-quick.md
@@ -46,23 +46,25 @@ hadoop ALL=(ALL) NOPASSWD: NOPASSWD: ALL
 , download the corresponding The installation package (project installation package and management console installation package)
 - Method 2: Compile the project installation package and management console according to [Linkis Compile and Package](../development/build) and [Front-end Management Console Compile](../development/build-console) Installation package
 
-After uploading the installation package `apache-linkis-x.x.x-incubating-bin.tar.gz`, decompress the installation package
+After uploading the installation package `apache-linkis-x.x.x-bin.tar.gz`, decompress the installation package
 
 ```shell script
-$ tar -xvf apache-linkis-x.x.x-incubating-bin.tar.gz
+$ tar -xvf apache-linkis-x.x.x-bin.tar.gz
 ````
 
 The unzipped directory structure is as follows
 ```shell script
--rw-r--r-- 1 hadoop hadoop 531847342 Feb 21 10:10 apache-linkis-1.0.3-incubating-bin.tar.gz
-drwxrwxr-x 2 hadoop hadoop 4096 Feb 21 10:13 bin //Script to perform environment check and install
-drwxrwxr-x 2 hadoop hadoop 4096 Feb 21 10:13 deploy-config // Environment configuration information such as DB that depends on deployment
--rw-r--r-- 1 hadoop hadoop 66058 Jan 22 2020 LICENSE
-drwxrwxr-x 2 hadoop hadoop 16384 Feb 21 10:13 licenses
-drwxrwxr-x 7 hadoop hadoop 4096 Feb 21 10:13 linkis-package // The actual package, including lib/service startup script tool/db initialization script/microservice configuration file, etc.
--rw-r--r-- 1 hadoop hadoop 83126 Jan 22 2020 NOTICE
--rw-r--r-- 1 hadoop hadoop 7900 Jan 22 2020 README_CN.md
--rw-r--r-- 1 hadoop hadoop 8184 Jan 22 2020 README.md
+-rw-r--r-- 1 hadoop hadoop 518192043 Jun 20 09:50 apache-linkis-1.3.1-bin.tar.gz
+drwxrwxr-x 2 hadoop hadoop      4096 Jun 20 09:56 bin //Script to perform environment check and install
+drwxrwxr-x 2 hadoop hadoop      4096 Jun 20 09:56 deploy-config // Environment configuration information such as DB that depends on deployment
+drwxrwxr-x 4 hadoop hadoop      4096 Jun 20 09:56 docker
+drwxrwxr-x 4 hadoop hadoop      4096 Jun 20 09:56 helm
+-rwxrwxr-x 1 hadoop hadoop     84732 Jan 22  2020 LICENSE
+drwxr-xr-x 2 hadoop hadoop     20480 Jun 20 09:56 licenses
+drwxrwxr-x 7 hadoop hadoop      4096 Jun 20 09:56 linkis-package // The actual package, including lib/service startup script tool/db initialization script/microservice configuration file, etc.
+-rwxrwxr-x 1 hadoop hadoop    119503 Jan 22  2020 NOTICE
+-rw-r--r-- 1 hadoop hadoop     11959 Jan 22  2020 README_CN.md
+-rw-r--r-- 1 hadoop hadoop     12587 Jan 22  2020 README.md
 
 ````
 


### PR DESCRIPTION
Remove "incubating" from deploy-quick.md of v1.3.1, v1.3.2 and v1.4.0 based on installation package of v1.3.1.
根据v1.3.1安装包，移除了v1.3.1、v1.3.2和v1.4.0单机部署文档中的incubating词。

Related issues: https://github.com/apache/linkis/issues/4668