### PR TITLE
Include OAuth documentation for 1.8.0

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.8.0/about/configuration.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.8.0/about/configuration.md
@@ -29,7 +29,7 @@ Linkis 支持运行在 Intel x86-64 架构的 64 位通用硬件服务器平台�
 | 16核+ | 32GB+ | SAS | 千兆网卡 | 1+  |
 
 > **注意：**
-> 
+>
 > - 以上建议配置为部署 Linkis的最低配置，生产环境强烈推荐使用更高的配置
 > - 硬盘大小配置建议 50GB+ ，系统盘和数据盘分开
 
@@ -92,7 +92,21 @@ Apache Linkis 可以通过参数接入LDAP实现多用户管理，可以在`link
 
 ![](./images/ldap.png)
 
-### 2.4 关闭资源检查
+### 2.4 OAuth设置
+Apache Linkis 可以通过参数接入OAuth实现SSO登录，可以在`linkis-mg-gateway.properties`替换或追加此配置。
+
+|           参数名          | 默认值   |  描述                                                       |
+| ------------------------- | -------  | -----------------------------------------------------------|
+| wds.linkis.gateway.conf.enable.oauth.auth | false  | 是否启用 OAuth 认证 |
+| wds.linkis.gateway.auth.oauth.authentication.url |  | OAuth 2.0 授权端点 URL，用于获取授权码 |
+| wds.linkis.gateway.auth.oauth.exchange.url |  | 令牌交换端点 URL，用于将授权码转换为访问令牌 |
+| wds.linkis.gateway.auth.oauth.validate.url |  | 用户验证端点 URL，用于通过访问令牌获取用户身份信息 |
+| wds.linkis.gateway.auth.oauth.validate.field |  | 包含用户名的 JSON 响应字段名 |
+| wds.linkis.gateway.auth.oauth.client.id |  | OAuth 客户端 ID |
+| wds.linkis.gateway.auth.oauth.client.secret |  | OAuth 客户端密钥 |
+| wds.linkis.gateway.auth.oauth.scope |  | OAuth 授权范围 |
+
+### 2.5 关闭资源检查
 Apache Linkis 提交任务时有时会调试异常，如：资源不足；可以在`linkis-cg-linkismanager.properties`替换或追加此配置。
 
 |           参数名          | 默认值   |  描述                                                       |
@@ -101,7 +115,7 @@ Apache Linkis 提交任务时有时会调试异常，如：资源不足；可以
 
 ![](./images/resource-enable.png)
 
-### 2.5 开启引擎调试
+### 2.6 开启引擎调试
 Apache Linkis EC可以开启调试模式，可以在`linkis-cg-linkismanager.properties`替换或追加此配置。
 
 |           参数名          | 默认值   |  描述                                                       |
@@ -110,7 +124,7 @@ Apache Linkis EC可以开启调试模式，可以在`linkis-cg-linkismanager.pro
 
 ![](./images/engine-debug.png)
 
-### 2.6 Hive元数据配置
+### 2.7 Hive元数据配置
 Apache Linkis 的public-service服务需要读取hive的元数据；可以在`linkis-ps-publicservice.properties`替换或追加此配置。
 
 |           参数名          | 默认值   |  描述                                                       |
@@ -121,7 +135,7 @@ Apache Linkis 的public-service服务需要读取hive的元数据；可以在`li
 
 ![](./images/hive-meta.png)
 
-### 2.7 Linkis 数据库配置
+### 2.8 Linkis 数据库配置
 Apache Linkis 访问默认使用Mysql作为数据存储，可以在`linkis.properties`替换或追加此配置。
 
 |           参数名          | 默认值   |  描述                                                       |
@@ -132,7 +146,7 @@ Apache Linkis 访问默认使用Mysql作为数据存储，可以在`linkis.prope
 
 ![](./images/linkis-db.png)
 
-### 2.8 Linkis Session 缓存配置
+### 2.9 Linkis Session 缓存配置
 Apache Linkis 支持使用redis进行session的共享；可以在`linkis.properties`替换或追加此配置。
 
 |           参数名          | 默认值   |  描述                                                       |
@@ -144,7 +158,7 @@ Apache Linkis 支持使用redis进行session的共享；可以在`linkis.propert
 
 ![](./images/redis.png)
 
-### 2.9 Linkis 模块开发配置
+### 2.10 Linkis 模块开发配置
 Apache Linkis 开发时可通过此参数，自定义加载模块的数据库、Rest接口、实体对象；可以在`linkis-ps-publicservice.properties`进行修改，多个模块之间使用逗号分割。
 
 |           参数名          | 默认值   |  描述                                                       |
@@ -156,7 +170,7 @@ Apache Linkis 开发时可通过此参数，自定义加载模块的数据库、
 
 ![](./images/deverlop-conf.png)
 
-### 2.10 Linkis 模块开发配置
+### 2.11 Linkis 模块开发配置
 Apache Linkis 开发时可通过此参数，自定义加载模块的路由；可以在`linkis.properties`进行修改，多个模块之间使用逗号分割。
 
 |           参数名          | 默认值   |  描述                                                       |
@@ -165,7 +179,7 @@ Apache Linkis 开发时可通过此参数，自定义加载模块的路由；可
 
 ![](./images/list-conf.png)
 
-### 2.11 Linkis 文件系统及物料存放路径
+### 2.12 Linkis 文件系统及物料存放路径
 Apache Linkis 开发时可通过此参数，自定义加载模块的路由；可以在`linkis.properties`进行修改，多个模块之间使用逗号分割。
 
 |           参数名          | 默认值   |  描述                                                       |

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.8.0/auth/oauth.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.8.0/auth/oauth.md
@@ -1,0 +1,40 @@
+---
+title: OAuth
+sidebar_position: 1
+---
+> OAuth（Open Authorization）是一个开放标准授权协议，允许第三方应用在用户授权后访问受保护资源，广泛应用于单点登录（SSO）场景。
+
+## 1. 实现逻辑介绍
+
+通过统一的认证处理filter:`org.apache.linkis.server.security.SecurityFilter` 来控制。
+
+1. 授权请求：后端根据配置生成授权链接，前端引导用户跳转至认证服务器
+2. 用户授权：用户通过认证后，认证服务器返回授权码
+3. 令牌获取：后端用授权码向认证服务器换取访问令牌
+4. 资源访问：后端携带令牌访问资源服务器，读取用户信息
+
+
+## 2. 使用方式
+
+默认兼容 GitHub OAuth 认证接口。
+
+### 2.1 Step 1 配置授权码接口
+
+```properties
+wds.linkis.oauth.enable=true
+wds.linkis.oauth.url=https://github.com/login/oauth/authorize
+wds.linkis.gateway.auth.oauth.exchange.url=https://github.com/login/oauth/access_token
+wds.linkis.gateway.auth.oauth.validate.url=https://api.github.com/user
+wds.linkis.gateway.auth.oauth.validate.field=login
+wds.linkis.gateway.auth.oauth.client.id=YOUR_CLIENT_ID
+wds.linkis.gateway.auth.oauth.client.secret=YOUR_CLIENT_SECRET
+wds.linkis.gateway.auth.oauth.scope=user
+```
+如果配置完成，登录页面将会自动显示 OAuth 授权登录按钮。
+
+### 2.2 Step 2 配置授权回调
+
+> [!NOTE]
+> 该项需要在授权服务器上配置。
+
+默认回调地址为：`http://{web_host}:{web_port}/login/oauth/callback?code={code}`

--- a/versioned_docs/version-1.8.0/about/configuration.md
+++ b/versioned_docs/version-1.8.0/about/configuration.md
@@ -93,7 +93,21 @@ Apache Linkis can access LDAP through parameters to achieve multi-user managemen
 
 ![](./images/ldap.png)
 
-### 2.4 Turn off resource checking
+### 2.4 OAuth Settings
+Apache Linkis can use OAuth to authenticate users, and this configuration can be replaced or added in `linkis-mg-gateway.properties`.
+
+| parameter name | default value | description |
+| ------------------------- | ------- | --------------------------------------------------------------|
+|wds.linkis.gateway.conf.enable.oauth.auth| false  | Whether to enable OAuth authentication |
+|wds.linkis.gateway.auth.oauth.authentication.url|  | OAuth 2.0 authorization endpoint URL for obtaining authorization code |
+|wds.linkis.gateway.auth.oauth.exchange.url|  |Token exchange endpoint URL for converting authorization code to access token |
+|wds.linkis.gateway.auth.oauth.validate.url|  |User validation endpoint URL for retrieving user identity via access token|
+|wds.linkis.gateway.auth.oauth.validate.field|  |JSON response field name containing username|
+|wds.linkis.gateway.auth.oauth.client.id|  | OAuth client ID|
+|wds.linkis.gateway.auth.oauth.client.secret|  | OAuth client secret|
+|wds.linkis.gateway.auth.oauth.scope|  | OAuth scope|
+
+### 2.5 Turn off resource checking
 Apache Linkis sometimes debugs exceptions when submitting tasks, such as: insufficient resources; you can replace or append this configuration in `linkis-cg-linkismanager.properties`.
 
 | parameter name | default value | description |
@@ -102,7 +116,7 @@ Apache Linkis sometimes debugs exceptions when submitting tasks, such as: insuff
 
 ![](./images/resource-enable.png)
 
-### 2.5 Enable engine debugging
+### 2.6 Enable engine debugging
 Apache Linkis EC can enable debugging mode, and this configuration can be replaced or added in `linkis-cg-linkismanager.properties`.
 
 | parameter name | default value | description |
@@ -111,7 +125,7 @@ Apache Linkis EC can enable debugging mode, and this configuration can be replac
 
 ![](./images/engine-debug.png)
 
-### 2.6 Hive metadata configuration
+### 2.7 Hive metadata configuration
 The public-service service of Apache Linkis needs to read hive metadata; this configuration can be replaced or appended in `linkis-ps-publicservice.properties`.
 
 | parameter name | default value | description |
@@ -122,7 +136,7 @@ The public-service service of Apache Linkis needs to read hive metadata; this co
 
 ![](./images/hive-meta.png)
 
-### 2.7 Linkis database configuration
+### 2.8 Linkis database configuration
 Apache Linkis access uses Mysql as data storage by default, you can replace or append this configuration in `linkis.properties`.
 
 | parameter name | default value | description |
@@ -133,7 +147,7 @@ Apache Linkis access uses Mysql as data storage by default, you can replace or a
 
 ![](./images/linkis-db.png)
 
-### 2.8 Linkis Session cache configuration
+### 2.9 Linkis Session cache configuration
 Apache Linkis supports using redis for session sharing; this configuration can be replaced or appended in `linkis.properties`.
 
 | parameter name | default value | description |
@@ -145,7 +159,7 @@ Apache Linkis supports using redis for session sharing; this configuration can b
 
 ![](./images/redis.png)
 
-### 2.9 Linkis module development configuration
+### 2.10 Linkis module development configuration
 When developing Apache Linkis, you can use this parameter to customize the database, Rest interface, and entity objects of the loading module; you can modify it in `linkis-ps-publicservice.properties`, and use commas to separate multiple modules.
 
 | parameter name | default value | description |
@@ -157,7 +171,7 @@ When developing Apache Linkis, you can use this parameter to customize the datab
 
 ![](./images/deverlop-conf.png)
 
-### 2.10 Linkis module development configuration
+### 2.11 Linkis module development configuration
 This parameter can be used to customize the route of loading modules during Apache Linkis development; it can be modified in `linkis.properties`, and commas are used to separate multiple modules.
 
 | parameter name | default value | description |
@@ -166,7 +180,7 @@ This parameter can be used to customize the route of loading modules during Apac
 
 ![](./images/list-conf.png)
 
-### 2.11 Linkis file system and material storage path
+### 2.12 Linkis file system and material storage path
 This parameter can be used to customize the route of loading modules during Apache Linkis development; it can be modified in `linkis.properties`, and commas are used to separate multiple modules.
 
 | parameter name | default value | description |

--- a/versioned_docs/version-1.8.0/auth/oauth.md
+++ b/versioned_docs/version-1.8.0/auth/oauth.md
@@ -1,0 +1,40 @@
+---
+title: OAuth
+sidebar_position: 1
+---
+> OAuth (Open Authorization) is an open standard authorization protocol that allows third-party applications to access protected resources after user authorization, widely used in Single Sign-On (SSO) scenarios.
+
+## 1. Implementation Logic
+
+Controlled through a unified authentication filter: `org.apache.linkis.server.security.SecurityFilter`.
+
+1. Authorization Request: Backend generates authorization link based on configuration, frontend redirects user to authentication server
+2. User Authorization: After user authentication, authentication server returns authorization code
+3. Token Acquisition: Backend exchanges authorization code for access token with authentication server
+4. Resource Access: Backend accesses resource server with token to retrieve user information
+
+## 2. Usage
+
+Default compatibility with GitHub OAuth authentication interface.
+
+### 2.1 Step 1 Configure Authorization Code Interface
+
+```properties
+wds.linkis.oauth.enable=true
+wds.linkis.oauth.url=https://github.com/login/oauth/authorize
+wds.linkis.gateway.auth.oauth.exchange.url=https://github.com/login/oauth/access_token
+wds.linkis.gateway.auth.oauth.validate.url=https://api.github.com/user
+wds.linkis.gateway.auth.oauth.validate.field=login
+wds.linkis.gateway.auth.oauth.client.id=YOUR_CLIENT_ID
+wds.linkis.gateway.auth.oauth.client.secret=YOUR_CLIENT_SECRET
+wds.linkis.gateway.auth.oauth.scope=user
+```
+
+If configuration is complete, the OAuth login button will automatically appear on the login page.
+
+### 2.2 Step 2 Configure Authorization Callback
+
+> [!NOTE]
+> This needs to be configured on the authorization server.
+
+Default callback address: `http://{web_host}:{web_port}/login/oauth/callback?code={code}`


### PR DESCRIPTION
The OAuth documentation were initially added in #811, but they were not copied over to the 1.8.0 in #812.