### PR TITLE
Fix GitHub icon alignment in navbar

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -217,14 +217,14 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
           ],
         },
         {
+          type: "localeDropdown",
+          position: "right",
+        },
+        {
           href: 'https://github.com/apache/linkis',
           'aria-label': 'GitHub',
           className: 'header-github-link',
           position: 'right',
-        },
-        {
-          type: "localeDropdown",
-          position: "right",
         },
       ],
     },


### PR DESCRIPTION
## Problem
- The GitHub icon in the navbar was not at the bottom in the sidebar.

## What Changed
- Adjusted the alignment of the GitHub icon.

## Screenshots
|Before|After|
|-------|------|
|<img width="399" height="595" alt="Screenshot 2026-02-05 235117" src="https://github.com/user-attachments/assets/97a6206e-f90b-4499-997d-34180325d350" />|<img width="396" height="563" alt="Screenshot 2026-02-05 235140" src="https://github.com/user-attachments/assets/a7b4923a-51fd-4801-8ff3-c5c3c1e17286" />|
|<img width="601" height="76" alt="Screenshot 2026-02-06 001049" src="https://github.com/user-attachments/assets/38173aba-b765-4e0c-818d-f80560f12cc7" />|<img width="581" height="74" alt="Screenshot 2026-02-06 001055" src="https://github.com/user-attachments/assets/9e767b8d-4711-4ca3-8ea6-be004a17e653" />|
|<img width="1919" height="79" alt="Screenshot 2026-02-05 235212" src="https://github.com/user-attachments/assets/28cfa353-9243-46b3-a9fb-fae5cd3df97a" />|<img width="1909" height="76" alt="Screenshot 2026-02-05 235206" src="https://github.com/user-attachments/assets/3edccfe7-171e-4eb1-9ff7-8138a830058b" />|